### PR TITLE
Fix spec version

### DIFF
--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.3
+specVersion: 0.0.1
 description: Melon protocol
 repository: https://github.com/melonproject/melon-subgraph
 schema:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.3
+specVersion: 0.0.1
 description: Melon protocol
 repository: https://github.com/melonproject/melon-subgraph
 schema:


### PR DESCRIPTION
The correct spec version is `0.0.1`, not `0.0.3` which is the api version.