### PR TITLE
Upgrade to version 0.15.1 of graph-node

### DIFF
--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node
+    image: graphprotocol/graph-node:latest
     ports:
       - "8000:8000"
       - "8001:8001"

--- a/docker-compose.osx.yml
+++ b/docker-compose.osx.yml
@@ -1,11 +1,11 @@
-version: '3'
+version: "3"
 services:
   graph-node:
     image: graphprotocol/graph-node
     ports:
-      - '8000:8000'
-      - '8001:8001'
-      - '8020:8020'
+      - "8000:8000"
+      - "8001:8001"
+      - "8020:8020"
     depends_on:
       - ipfs
       - postgres
@@ -14,19 +14,19 @@ services:
       postgres_user: graph-node
       postgres_pass: let-me-in
       postgres_db: graph-node
-      ipfs: 'ipfs:5001'
-      ethereum: 'mainnet:https://mainnet.infura.io/v3/b704ae8aa546415fa97118ac9102ec13'
+      ipfs: "ipfs:5001"
+      ethereum: "mainnet:https://mainnet.infura.io/v3/b704ae8aa546415fa97118ac9102ec13"
       RUST_LOG: info
   ipfs:
     image: ipfs/go-ipfs
     ports:
-      - '5001:5001'
+      - "5001:5001"
     volumes:
       - ./data/ipfs:/data/ipfs
   postgres:
     image: postgres
     ports:
-      - '5432:5432'
+      - "5432:5432"
     environment:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "auth": "graph auth https://api.thegraph.com/deploy/",
     "deploy": "graph deploy melonproject/melon --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:test": "graph deploy iherger/melontest --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy:kovan": "graph deploy iherger/melon-kovan --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "create:local": "graph create melonproject/melon --node http://127.0.0.1:8020",
     "deploy:local": "graph deploy melonproject/melon --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.13.1",
-    "@graphprotocol/graph-ts": "^0.13.0",
+    "@graphprotocol/graph-cli": "^0.15.0",
+    "@graphprotocol/graph-ts": "^0.15.0",
     "@melonproject/protocol": "^1.0.9",
     "@melonproject/protocol-v.1.0.1": "npm:@melonproject/protocol@1.0.1",
     "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "auth": "graph auth https://api.thegraph.com/deploy/",
     "deploy": "graph deploy melonproject/melon --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:test": "graph deploy iherger/melontest --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy:ash:kovan": "graph deploy iherger/melon-ash-kovan subgraph.ash.kovan.yaml --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ ",
     "deploy:kovan": "graph deploy iherger/melon-kovan --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "create:local": "graph create melonproject/melon --node http://127.0.0.1:8020",
     "deploy:local": "graph deploy melonproject/melon --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "auth": "graph auth https://api.thegraph.com/deploy/",
     "deploy": "graph deploy melonproject/melon --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:test": "graph deploy iherger/melontest --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
-    "deploy:ash:kovan": "graph deploy iherger/melon-ash-kovan subgraph.ash.kovan.yaml --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ ",
+    "deploy:kovan:ash": "graph deploy iherger/melon-ash-kovan subgraph.ash.kovan.yaml --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ ",
     "deploy:kovan": "graph deploy iherger/melon-kovan --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "create:local": "graph create melonproject/melon --node http://127.0.0.1:8020",
     "deploy:local": "graph deploy melonproject/melon --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "codegen": "graph codegen --debug --output-dir src/types/",
     "build": "graph build --debug",
     "auth": "graph auth https://api.thegraph.com/deploy/",
-    "deploy": "graph deploy melonproject/melon --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy:prod": "graph deploy melonproject/melon --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy:dev": "graph deploy melonproject/melon-dev --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:test": "graph deploy iherger/melontest --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy:kovan:ash": "graph deploy iherger/melon-ash-kovan subgraph.ash.kovan.yaml --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ ",
     "deploy:kovan": "graph deploy iherger/melon-kovan --debug --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
@@ -14,12 +15,15 @@
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.15.0",
-    "@graphprotocol/graph-ts": "^0.15.0",
+    "@graphprotocol/graph-ts": "^0.15.1",
     "@melonproject/protocol": "^1.0.9",
     "@melonproject/protocol-v.1.0.1": "npm:@melonproject/protocol@1.0.1",
     "commander": "^2.20.0",
     "glob": "^7.1.4",
     "inquirer": "^6.3.1",
     "mustache": "^3.0.1"
+  },
+  "dependencies": {
+    "global": "^4.4.0"
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -45,17 +45,17 @@ type Version @entity {
 type Engine @entity {
   id: ID!
   registry: Registry!
-  amguPrice: BigInt
-  frozenEther: BigInt
-  liquidEther: BigInt
-  lastThaw: BigInt
-  thawingDelay: BigInt
-  totalEtherConsumed: BigInt
-  totalAmguConsumed: BigInt
-  totalMlnBurned: BigInt
-  premiumPercent: BigInt
-  mlnTotalSupply: BigInt
-  lastUpdate: BigInt
+  amguPrice: BigInt!
+  frozenEther: BigInt!
+  liquidEther: BigInt!
+  lastThaw: BigInt!
+  thawingDelay: BigInt!
+  totalEtherConsumed: BigInt!
+  totalAmguConsumed: BigInt!
+  totalMlnBurned: BigInt!
+  premiumPercent: BigInt!
+  mlnTotalSupply: BigInt!
+  lastUpdate: BigInt!
   history: [EngineHistory!]! @derivedFrom(field: "engine")
   amguPrices: [AmguPrice!]! @derivedFrom(field: "engine")
   amguPayments: [AmguPayment!]! @derivedFrom(field: "engine")
@@ -194,6 +194,7 @@ type Fund @entity {
   share: Share!
   trading: Trading!
   vault: Vault!
+  priceSource: PriceSource!
   registry: Registry!
   version: Version!
   engine: Engine!

--- a/schema.graphql
+++ b/schema.graphql
@@ -17,6 +17,7 @@ type State @entity {
   timestamptNumberOfInvestors: BigInt!
   lastEngineUpdate: BigInt!
   currentEngine: Engine
+  mlnToken: String!
 }
 
 type Registry @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -25,7 +25,7 @@ type Registry @entity {
   id: ID!
   owner: String!
   engine: Engine
-  versions: [Version!]! @derivedFrom(field: "registry")
+  versions: [Version!] @derivedFrom(field: "registry")
   assets: [Asset!]! @derivedFrom(field: "registry")
   exchangeAdapters: [ExchangeAdapter!]! @derivedFrom(field: "registry")
   priceSources: [PriceSource!]! @derivedFrom(field: "registry")
@@ -39,7 +39,7 @@ type Version @entity {
   id: ID!
   registry: Registry
   name: String
-  funds: [Fund!]! @derivedFrom(field: "version")
+  funds: [Fund!] @derivedFrom(field: "version")
 }
 
 type Engine @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -25,7 +25,7 @@ type Registry @entity {
   id: ID!
   owner: String!
   engine: Engine
-  versions: [Version!] @derivedFrom(field: "registry")
+  versions: [Version!]!
   assets: [Asset!]! @derivedFrom(field: "registry")
   exchangeAdapters: [ExchangeAdapter!]! @derivedFrom(field: "registry")
   priceSources: [PriceSource!]! @derivedFrom(field: "registry")
@@ -37,9 +37,9 @@ type Registry @entity {
 
 type Version @entity {
   id: ID!
-  registry: Registry
+  registry: Registry!
   name: String
-  funds: [Fund!] @derivedFrom(field: "version")
+  funds: [Fund!]!
 }
 
 type Engine @entity {
@@ -207,7 +207,7 @@ type Fund @entity {
   gavPerShareNetManagementFee: BigInt
   allocatedFees: BigInt
   totalSupply: BigInt
-  investments: [Investment!]! @derivedFrom(field: "fund")
+  investments: [Investment!]!
   calculationsHistory: [FundCalculationsHistory!]! @derivedFrom(field: "fund")
   investmentHistory: [InvestmentHistory!]! @derivedFrom(field: "fund")
   holdingsHistory: [FundHoldingsHistory!]! @derivedFrom(field: "fund")

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,6 +18,7 @@ type State @entity {
   lastEngineUpdate: BigInt!
   currentEngine: Engine
   mlnToken: String!
+  registry: Registry
 }
 
 type Registry @entity {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,55 +1,71 @@
 #!/usr/bin/env node
 
-const commander = require('commander');
-const glob = require('glob');
-const path = require('path');
-const fs = require('fs');
-const inquirer = require('inquirer');
-const mustache = require('mustache');
+const commander = require("commander");
+const glob = require("glob");
+const path = require("path");
+const fs = require("fs");
+const inquirer = require("inquirer");
+const mustache = require("mustache");
 
-commander.command('generate-subgraph [<deployment>]').action(async deployment => {
-  const protocol = path.dirname(require.resolve('@melonproject/protocol/package.json'));
-  const dir = path.join(protocol, 'deployments');
-  const files = glob.sync('*.json', {
-    cwd: dir,
+commander
+  .command("generate-subgraph [<deployment>]")
+  .action(async deployment => {
+    const protocol = path.dirname(
+      require.resolve("@melonproject/protocol/package.json")
+    );
+    const dir = path.join(protocol, "deployments");
+    const files = glob.sync("*.json", {
+      cwd: dir
+    });
+
+    const file = await (async () => {
+      if (!!deployment) {
+        return path.join(dir, deployment);
+      }
+
+      const { answer } = await inquirer.prompt([
+        {
+          type: "list",
+          name: "answer",
+          message: "Which deployment do you want to use?",
+          choices: files
+        }
+      ]);
+
+      return path.join(dir, answer);
+    })();
+
+    const view = JSON.parse(
+      fs.readFileSync(file, {
+        encoding: "UTF-8"
+      })
+    );
+
+    view.meta.network = view.meta.chain === 1 ? "mainnet" : "kovan";
+
+    const rootDir = path.join(__dirname, "..");
+    const staticsTemplate = fs.readFileSync(
+      path.join(rootDir, "src", "statics.template.ts"),
+      {
+        encoding: "UTF-8"
+      }
+    );
+
+    const subgraphTemplate = fs.readFileSync(
+      path.join(rootDir, "subgraph.template.yaml"),
+      {
+        encoding: "UTF-8"
+      }
+    );
+
+    const subgraphOutput = mustache.render(subgraphTemplate, view);
+    const staticsOutput = mustache.render(staticsTemplate, view);
+
+    fs.writeFileSync(path.join(rootDir, "subgraph.yaml"), subgraphOutput);
+    fs.writeFileSync(path.join(rootDir, "src", "statics.ts"), staticsOutput);
   });
 
-  const file = await (async () => {
-    if (!!deployment) {
-      return path.join(dir, deployment);
-    }
-
-    const { answer } = await inquirer.prompt([{
-      type: 'list',
-      name: 'answer',
-      message: 'Which deployment do you want to use?',
-      choices: files,
-    }]);
-
-    return path.join(dir, answer);
-  })();
-
-  const view = JSON.parse(fs.readFileSync(file, {
-    encoding: 'UTF-8'
-  }));
-
-  const rootDir = path.join(__dirname, '..');
-  const staticsTemplate = fs.readFileSync(path.join(rootDir, 'src', 'statics.template.ts'), {
-    encoding: 'UTF-8',
-  });
-
-  const subgraphTemplate = fs.readFileSync(path.join(rootDir, 'subgraph.template.yaml'), {
-    encoding: 'UTF-8',
-  });
-
-  const subgraphOutput = mustache.render(subgraphTemplate, view);
-  const staticsOutput = mustache.render(staticsTemplate, view);
-
-  fs.writeFileSync(path.join(rootDir, 'subgraph.yaml'), subgraphOutput);
-  fs.writeFileSync(path.join(rootDir, 'src', 'statics.ts'), staticsOutput);
-});
-
-commander.on('command:*', () => {
+commander.on("command:*", () => {
   commander.help();
   process.exit(1);
 });
@@ -59,4 +75,3 @@ if (!commander.args.length) {
   commander.help();
   process.exit(1);
 }
-

--- a/src/mappings/Accounting.ts
+++ b/src/mappings/Accounting.ts
@@ -6,13 +6,21 @@ import { Accounting, Asset } from "../types/schema";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleAssetAddition(event: AssetAddition): void {
-  let accounting = Accounting.load(event.address.toHex()) as Accounting;
+  let accounting = Accounting.load(event.address.toHex());
+  if (!accounting) {
+    return;
+  }
+
+  let asset = Asset.load(event.params.asset.toHex());
+  if (!asset) {
+    return;
+  }
+
   accounting.ownedAssets = accounting.ownedAssets.concat([
     event.params.asset.toHex()
   ]);
   accounting.save();
 
-  let asset = Asset.load(event.params.asset.toHex()) as Asset;
   asset.fundAccountings = asset.fundAccountings.concat([event.address.toHex()]);
   asset.save();
 
@@ -31,7 +39,16 @@ export function handleAssetAddition(event: AssetAddition): void {
 }
 
 export function handleAssetRemoval(event: AssetRemoval): void {
-  let accounting = Accounting.load(event.address.toHex()) as Accounting;
+  let accounting = Accounting.load(event.address.toHex());
+  if (!accounting) {
+    return;
+  }
+
+  let asset = Asset.load(event.params.asset.toHex());
+  if (!asset) {
+    return;
+  }
+
   let removed = event.params.asset.toHex();
   let owned = new Array<string>();
   for (let i: i32 = 0; i < accounting.ownedAssets.length; i++) {
@@ -43,7 +60,6 @@ export function handleAssetRemoval(event: AssetRemoval): void {
   accounting.ownedAssets = owned;
   accounting.save();
 
-  let asset = Asset.load(event.params.asset.toHex()) as Asset;
   let removedAccountings = event.address.toHex();
   let remainingAccountings = new Array<string>();
   for (let i: i32 = 0; i < asset.fundAccountings.length; i++) {

--- a/src/mappings/Accounting.ts
+++ b/src/mappings/Accounting.ts
@@ -1,7 +1,7 @@
 import {
   AssetAddition,
   AssetRemoval
-} from "../types/AccountingFactoryDataSource/templates/AccountingDataSource/AccountingContract";
+} from "../types/templates/AccountingDataSource/AccountingContract";
 import { Accounting, Asset } from "../types/schema";
 import { saveEventHistory } from "./utils/saveEventHistory";
 

--- a/src/mappings/AccountingFactory.ts
+++ b/src/mappings/AccountingFactory.ts
@@ -1,5 +1,5 @@
 import { NewInstance } from "../types/AccountingFactoryDataSource/AccountingFactoryContract";
-import { AccountingDataSource } from "../types/AccountingFactoryDataSource/templates";
+import { AccountingDataSource } from "../types/templates";
 import { Accounting, EventHistory } from "../types/schema";
 import { saveContract } from "./utils/saveContract";
 import { saveEventHistoryParameters } from "./utils/saveEventHistoryParameters";

--- a/src/mappings/Engine.ts
+++ b/src/mappings/Engine.ts
@@ -12,7 +12,8 @@ import {
   EngineEtherEvent,
   Registry,
   Engine,
-  EngineHistory
+  EngineHistory,
+  State
 } from "../types/schema";
 import { Address, BigInt, log } from "@graphprotocol/graph-ts";
 import { saveContract } from "./utils/saveContract";
@@ -87,7 +88,7 @@ export function handleAmguPaid(event: AmguPaid): void {
     state.save();
 
     let mlnContract = MlnContract.bind(
-      Address.fromString("0xec67005c4e498ec7f55e092bd1d35cbc47c91892")
+      Address.fromString(state.mlnToken as string)
     );
 
     engine.amguPrice = engineContract.amguPrice();
@@ -99,7 +100,9 @@ export function handleAmguPaid(event: AmguPaid): void {
     engine.totalAmguConsumed = engineContract.totalAmguConsumed();
     engine.totalMlnBurned = engineContract.totalMlnBurned();
     engine.premiumPercent = engineContract.premiumPercent();
-    engine.mlnTotalSupply = mlnContract.totalSupply();
+    engine.mlnTotalSupply = mlnContract.try_totalSupply().reverted
+      ? BigInt.fromI32(0)
+      : mlnContract.try_totalSupply().value;
     engine.lastUpdate = event.block.timestamp;
     engine.save();
 

--- a/src/mappings/Engine.ts
+++ b/src/mappings/Engine.ts
@@ -10,42 +10,13 @@ import {
   AmguPrice,
   AmguPayment,
   EngineEtherEvent,
-  Registry,
   Engine,
-  EngineHistory,
-  State
+  EngineHistory
 } from "../types/schema";
 import { Address, BigInt, log } from "@graphprotocol/graph-ts";
 import { saveContract } from "./utils/saveContract";
 import { currentState } from "./utils/currentState";
 import { MlnContract } from "../types/EngineDataSource/MlnContract";
-
-function engineEntity(address: Address, registry: Address): Engine {
-  let id = address.toHex();
-  let engine = Engine.load(id);
-
-  if (!engine) {
-    engine = new Engine(id);
-    engine.registry = registry.toHex();
-    engine.save();
-  }
-
-  return engine as Engine;
-}
-
-function registryEntity(address: Address): Registry {
-  let id = address.toHex();
-  let registry = Registry.load(id);
-
-  if (!registry) {
-    registry = new Registry(id);
-    registry.versions = [];
-    registry.assets = [];
-    registry.save();
-  }
-
-  return registry as Registry;
-}
 
 export function handleSetAmguPrice(event: SetAmguPrice): void {
   let amguPrice = new AmguPrice(event.transaction.hash.toHex());

--- a/src/mappings/Engine.ts
+++ b/src/mappings/Engine.ts
@@ -52,49 +52,49 @@ export function handleAmguPaid(event: AmguPaid): void {
   engine.lastUpdate = event.block.timestamp;
   engine.save();
 
-  // // Update all engine quantities every hour
-  // let state = currentState();
-  // let interval = BigInt.fromI32(60 * 60);
-  // if (event.block.timestamp.minus(state.lastEngineUpdate).gt(interval)) {
-  //   state.lastEngineUpdate = event.block.timestamp;
-  //   state.save();
+  // Update all engine quantities every hour
+  let state = currentState();
+  let interval = BigInt.fromI32(60 * 60);
+  if (event.block.timestamp.minus(state.lastEngineUpdate).gt(interval)) {
+    state.lastEngineUpdate = event.block.timestamp;
+    state.save();
 
-  //   if (state.mlnToken == "") {
-  //     return;
-  //   }
-  //   let mlnContract = MlnContract.bind(
-  //     Address.fromString(state.mlnToken as string)
-  //   );
+    if (state.mlnToken == "") {
+      return;
+    }
+    let mlnContract = MlnContract.bind(
+      Address.fromString(state.mlnToken as string)
+    );
 
-  //   engine.amguPrice = engineContract.amguPrice();
-  //   engine.liquidEther = engineContract.liquidEther();
-  //   engine.lastThaw = engineContract.lastThaw();
-  //   engine.thawingDelay = engineContract.thawingDelay();
-  //   engine.totalAmguConsumed = engineContract.totalAmguConsumed();
-  //   engine.totalMlnBurned = engineContract.totalMlnBurned();
-  //   engine.premiumPercent = engineContract.premiumPercent();
-  //   engine.mlnTotalSupply = mlnContract.try_totalSupply().reverted
-  //     ? BigInt.fromI32(0)
-  //     : mlnContract.try_totalSupply().value;
-  //   engine.save();
+    engine.amguPrice = engineContract.amguPrice();
+    engine.liquidEther = engineContract.liquidEther();
+    engine.lastThaw = engineContract.lastThaw();
+    engine.thawingDelay = engineContract.thawingDelay();
+    engine.totalAmguConsumed = engineContract.totalAmguConsumed();
+    engine.totalMlnBurned = engineContract.totalMlnBurned();
+    engine.premiumPercent = engineContract.premiumPercent();
+    engine.mlnTotalSupply = mlnContract.try_totalSupply().reverted
+      ? BigInt.fromI32(0)
+      : mlnContract.try_totalSupply().value;
+    engine.save();
 
-  //   let engineHistory = new EngineHistory(
-  //     event.address.toHex() + "/" + event.block.timestamp.toString()
-  //   );
-  //   engineHistory.amguPrice = engine.amguPrice;
-  //   engineHistory.frozenEther = engine.frozenEther;
-  //   engineHistory.liquidEther = engine.liquidEther;
-  //   engineHistory.lastThaw = engine.lastThaw;
-  //   engineHistory.thawingDelay = engine.thawingDelay;
-  //   engineHistory.totalEtherConsumed = engine.totalEtherConsumed;
-  //   engineHistory.totalAmguConsumed = engine.totalAmguConsumed;
-  //   engineHistory.totalMlnBurned = engine.totalMlnBurned;
-  //   engineHistory.premiumPercent = engine.premiumPercent;
-  //   engineHistory.mlnTotalSupply = engine.mlnTotalSupply;
-  //   engineHistory.timestamp = event.block.timestamp;
-  //   engineHistory.engine = event.address.toHex();
-  //   engineHistory.save();
-  // }
+    let engineHistory = new EngineHistory(
+      event.address.toHex() + "/" + event.block.timestamp.toString()
+    );
+    engineHistory.amguPrice = engine.amguPrice;
+    engineHistory.frozenEther = engine.frozenEther;
+    engineHistory.liquidEther = engine.liquidEther;
+    engineHistory.lastThaw = engine.lastThaw;
+    engineHistory.thawingDelay = engine.thawingDelay;
+    engineHistory.totalEtherConsumed = engine.totalEtherConsumed;
+    engineHistory.totalAmguConsumed = engine.totalAmguConsumed;
+    engineHistory.totalMlnBurned = engine.totalMlnBurned;
+    engineHistory.premiumPercent = engine.premiumPercent;
+    engineHistory.mlnTotalSupply = engine.mlnTotalSupply;
+    engineHistory.timestamp = event.block.timestamp;
+    engineHistory.engine = event.address.toHex();
+    engineHistory.save();
+  }
 }
 
 export function handleThaw(event: Thaw): void {

--- a/src/mappings/Engine.ts
+++ b/src/mappings/Engine.ts
@@ -58,6 +58,9 @@ export function handleAmguPaid(event: AmguPaid): void {
     state.lastEngineUpdate = event.block.timestamp;
     state.save();
 
+    if (state.mlnToken == "") {
+      return;
+    }
     let mlnContract = MlnContract.bind(
       Address.fromString(state.mlnToken as string)
     );

--- a/src/mappings/Engine.ts
+++ b/src/mappings/Engine.ts
@@ -66,33 +66,30 @@ export function handleAmguPaid(event: AmguPaid): void {
     );
 
     engine.amguPrice = engineContract.amguPrice();
-    // engine.frozenEther = engineContract.frozenEther();
     engine.liquidEther = engineContract.liquidEther();
     engine.lastThaw = engineContract.lastThaw();
     engine.thawingDelay = engineContract.thawingDelay();
-    engine.totalEtherConsumed = engineContract.totalEtherConsumed();
     engine.totalAmguConsumed = engineContract.totalAmguConsumed();
     engine.totalMlnBurned = engineContract.totalMlnBurned();
     engine.premiumPercent = engineContract.premiumPercent();
     engine.mlnTotalSupply = mlnContract.try_totalSupply().reverted
       ? BigInt.fromI32(0)
       : mlnContract.try_totalSupply().value;
-    engine.lastUpdate = event.block.timestamp;
     engine.save();
 
     let engineHistory = new EngineHistory(
       event.address.toHex() + "/" + event.block.timestamp.toString()
     );
-    engineHistory.amguPrice = engine.amguPrice as BigInt;
-    engineHistory.frozenEther = engineContract.frozenEther();
-    engineHistory.liquidEther = engine.liquidEther as BigInt;
-    engineHistory.lastThaw = engine.lastThaw as BigInt;
-    engineHistory.thawingDelay = engine.thawingDelay as BigInt;
-    // engineHistory.totalEtherConsumed = engineContract.totalEtherConsumed();
-    engineHistory.totalAmguConsumed = engine.totalAmguConsumed as BigInt;
-    engineHistory.totalMlnBurned = engine.totalMlnBurned as BigInt;
-    engineHistory.premiumPercent = engine.premiumPercent as BigInt;
-    engineHistory.mlnTotalSupply = engine.mlnTotalSupply as BigInt;
+    engineHistory.amguPrice = engine.amguPrice;
+    engineHistory.frozenEther = engine.frozenEther;
+    engineHistory.liquidEther = engine.liquidEther;
+    engineHistory.lastThaw = engine.lastThaw;
+    engineHistory.thawingDelay = engine.thawingDelay;
+    engineHistory.totalEtherConsumed = engine.totalEtherConsumed;
+    engineHistory.totalAmguConsumed = engine.totalAmguConsumed;
+    engineHistory.totalMlnBurned = engine.totalMlnBurned;
+    engineHistory.premiumPercent = engine.premiumPercent;
+    engineHistory.mlnTotalSupply = engine.mlnTotalSupply;
     engineHistory.timestamp = event.block.timestamp;
     engineHistory.engine = event.address.toHex();
     engineHistory.save();

--- a/src/mappings/FeeManager.ts
+++ b/src/mappings/FeeManager.ts
@@ -112,8 +112,8 @@ export function handleFeeReward(event: FeeReward): void {
   let managerAddress = hubContract.manager();
 
   let investment = investmentEntity(
-    managerAddress,
-    hubAddress,
+    managerAddress.toHex(),
+    hubAddress.toHex(),
     event.block.timestamp
   );
   investment.shares = investment.shares.plus(event.params.shareQuantity);

--- a/src/mappings/FeeManager.ts
+++ b/src/mappings/FeeManager.ts
@@ -1,7 +1,7 @@
 import {
   FeeRegistration,
   FeeReward
-} from "../types/FeeManagerFactoryDataSource/templates/FeeManagerDataSource/FeeManagerContract";
+} from "../types/templates/FeeManagerDataSource/FeeManagerContract";
 import {
   FeeManager,
   ManagementFee,
@@ -10,10 +10,10 @@ import {
 } from "../types/schema";
 import { investmentEntity } from "./entities/investmentEntity";
 import { FeeManagerContract } from "../types/PriceSourceDataSource/FeeManagerContract";
-import { HubContract } from "../types/ParticipationFactoryDataSource/templates/ParticipationDataSource/HubContract";
+import { HubContract } from "../types/templates/ParticipationDataSource/HubContract";
 import { BigInt } from "@graphprotocol/graph-ts";
-import { ManagementFeeContract } from "../types/FeeManagerFactoryDataSource/templates/FeeManagerDataSource/ManagementFeeContract";
-import { PerformanceFeeContract } from "../types/FeeManagerFactoryDataSource/templates/FeeManagerDataSource/PerformanceFeeContract";
+import { ManagementFeeContract } from "../types/templates/FeeManagerDataSource/ManagementFeeContract";
+import { PerformanceFeeContract } from "../types/templates/FeeManagerDataSource/PerformanceFeeContract";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleFeeRegistration(event: FeeRegistration): void {

--- a/src/mappings/FeeManager.ts
+++ b/src/mappings/FeeManager.ts
@@ -26,6 +26,8 @@ export function handleFeeRegistration(event: FeeRegistration): void {
     feeManager.save();
   }
   let feeManagerContract = FeeManagerContract.bind(event.address);
+
+  // fee[0] is the management fee
   if (
     !feeManager.feesRegistered ||
     feeManager.feesRegistered.equals(BigInt.fromI32(0))
@@ -51,7 +53,9 @@ export function handleFeeRegistration(event: FeeRegistration): void {
       ["feeType", "rate"],
       ["Management Fee", mgmtFee.managementFeeRate.toString()]
     );
-  } else {
+  }
+  // fee[1] is the performance fee
+  else {
     let perfFeeAddress = feeManagerContract.fees(BigInt.fromI32(1));
     let perfFeeContract = PerformanceFeeContract.bind(perfFeeAddress);
     let perfFee = new PerformanceFee(event.address.toHex() + "/perf");

--- a/src/mappings/FeeManagerFactory.ts
+++ b/src/mappings/FeeManagerFactory.ts
@@ -1,4 +1,4 @@
-import { FeeManagerDataSource } from "../types/FeeManagerFactoryDataSource/templates";
+import { FeeManagerDataSource } from "../types/templates";
 import {
   NewInstance,
   CreateInstanceCall

--- a/src/mappings/FeeManagerFactory.ts
+++ b/src/mappings/FeeManagerFactory.ts
@@ -5,7 +5,7 @@ import {
 } from "../types/FeeManagerFactoryDataSource/FeeManagerFactoryContract";
 import { FeeManager } from "../types/schema";
 import { saveContract } from "./utils/saveContract";
-import { log, BigInt } from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleNewInstance(event: NewInstance): void {

--- a/src/mappings/Hub.ts
+++ b/src/mappings/Hub.ts
@@ -2,7 +2,7 @@ import {
   FundShutDown,
   LogSetOwner,
   HubContract
-} from "../types/VersionDataSource/templates/HubDataSource/HubContract";
+} from "../types/templates/HubDataSource/HubContract";
 import { Fund, FundCount } from "../types/schema";
 import { BigInt, log } from "@graphprotocol/graph-ts";
 import { currentState } from "./utils/currentState";

--- a/src/mappings/Hub.ts
+++ b/src/mappings/Hub.ts
@@ -4,15 +4,9 @@ import {
   HubContract
 } from "../types/templates/HubDataSource/HubContract";
 import { Fund, FundCount } from "../types/schema";
-import { BigInt, log } from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 import { currentState } from "./utils/currentState";
 import { saveEventHistory } from "./utils/saveEventHistory";
-import { saveContract } from "./utils/saveContract";
-
-export function handleLogSetOwner(event: LogSetOwner): void {
-  // we never actually get here because the Hub datasource is
-  // only instantiated after this event has been emitted
-}
 
 export function handleFundShutDown(event: FundShutDown): void {
   let fund = new Fund(event.address.toHex());

--- a/src/mappings/Participation.ts
+++ b/src/mappings/Participation.ts
@@ -144,7 +144,7 @@ export function handleRequestExecution(event: RequestExecution): void {
   let currentSharePrice = accountingContract.calcSharePrice();
   let gav = accountingContract.calcGav();
 
-  let sharesContract = SharesContract.bind(Address.fromString(fund.accounting));
+  let sharesContract = SharesContract.bind(Address.fromString(fund.share));
   let totalSupply = sharesContract.totalSupply();
 
   let requestedShares = event.params.requestedShares;
@@ -163,6 +163,9 @@ export function handleRequestExecution(event: RequestExecution): void {
   investment.shares = investment.shares.plus(requestedShares);
   investment.sharePrice = currentSharePrice;
   investment.save();
+
+  fund.investments = fund.investments.concat([investment.id]);
+  fund.save();
 
   archiveInvestmentRequest(
     event.params.requestOwner.toHex(),

--- a/src/mappings/Participation.ts
+++ b/src/mappings/Participation.ts
@@ -7,7 +7,7 @@ import {
   DisableInvestment,
   InvestmentRequest,
   CancelRequest
-} from "../types/ParticipationFactoryDataSource/templates/ParticipationDataSource/ParticipationContract";
+} from "../types/templates/ParticipationDataSource/ParticipationContract";
 import {
   Participation,
   Fund,
@@ -17,13 +17,13 @@ import {
   FundCalculationsHistory,
   FundHoldingsHistory
 } from "../types/schema";
-import { HubContract } from "../types/ParticipationFactoryDataSource/templates/ParticipationDataSource/HubContract";
-import { AccountingContract } from "../types/ParticipationFactoryDataSource/templates/ParticipationDataSource/AccountingContract";
-import { SharesContract } from "../types/ParticipationFactoryDataSource/templates/ParticipationDataSource/SharesContract";
+import { HubContract } from "../types/templates/ParticipationDataSource/HubContract";
+import { AccountingContract } from "../types/templates/ParticipationDataSource/AccountingContract";
+import { SharesContract } from "../types/templates/ParticipationDataSource/SharesContract";
 
 import { currentState } from "./utils/currentState";
 import { store, BigInt } from "@graphprotocol/graph-ts";
-import { PriceSourceContract } from "../types/ParticipationFactoryDataSource/templates/ParticipationDataSource/PriceSourceContract";
+import { PriceSourceContract } from "../types/templates/ParticipationDataSource/PriceSourceContract";
 import { investorEntity } from "./entities/investorEntity";
 import { saveEventHistory } from "./utils/saveEventHistory";
 

--- a/src/mappings/Participation.ts
+++ b/src/mappings/Participation.ts
@@ -76,7 +76,7 @@ export function handleInvestmentRequest(event: InvestmentRequest): void {
   );
   investmentRequest.fund = hub.toHex();
   investmentRequest.owner = investorEntity(
-    requestOwner,
+    requestOwner.toHex(),
     event.block.timestamp
   ).id;
   investmentRequest.shares = requestedShares;
@@ -156,8 +156,8 @@ export function handleRequestExecution(event: RequestExecution): void {
     .div(totalSupply);
 
   let investment = investmentEntity(
-    event.params.requestOwner,
-    Address.fromString(fund.id),
+    event.params.requestOwner.toHex(),
+    fund.id,
     event.block.timestamp
   );
   investment.shares = investment.shares.plus(requestedShares);
@@ -316,8 +316,8 @@ export function handleRedemption(event: Redemption): void {
     .div(defaultSharePrice);
 
   let investment = investmentEntity(
-    event.params.redeemer,
-    hub,
+    event.params.redeemer.toHex(),
+    hub.toHex(),
     event.block.timestamp
   );
   investment.shares = investment.shares.minus(event.params.redeemedShares);

--- a/src/mappings/ParticipationFactory.ts
+++ b/src/mappings/ParticipationFactory.ts
@@ -1,5 +1,5 @@
 import { NewInstance } from "../types/ParticipationFactoryDataSource/ParticipationFactoryContract";
-import { ParticipationDataSource } from "../types/ParticipationFactoryDataSource/templates";
+import { ParticipationDataSource } from "../types/templates";
 import { Participation } from "../types/schema";
 import { saveContract } from "./utils/saveContract";
 import { saveEventHistory } from "./utils/saveEventHistory";

--- a/src/mappings/PolicyManager.ts
+++ b/src/mappings/PolicyManager.ts
@@ -1,14 +1,14 @@
 import {
   Registration,
   PolicyManagerContract
-} from "../types/PolicyManagerFactoryDataSource/templates/PolicyManagerDataSource/PolicyManagerContract";
+} from "../types/templates/PolicyManagerDataSource/PolicyManagerContract";
 import { Policy } from "../types/schema";
-import { PolicyContract } from "../types/PolicyManagerFactoryDataSource/templates/PolicyManagerDataSource/PolicyContract";
-import { PriceToleranceContract } from "../types/PolicyManagerFactoryDataSource/templates/PolicyManagerDataSource/PriceToleranceContract";
-import { MaxPositionsContract } from "../types/PolicyManagerFactoryDataSource/templates/PolicyManagerDataSource/MaxPositionsContract";
-import { MaxConcentrationContract } from "../types/PolicyManagerFactoryDataSource/templates/PolicyManagerDataSource/MaxConcentrationContract";
-import { AssetWhiteListContract } from "../types/PolicyManagerFactoryDataSource/templates/PolicyManagerDataSource/AssetWhiteListContract";
-import { AssetBlackListContract } from "../types/PolicyManagerFactoryDataSource/templates/PolicyManagerDataSource/AssetBlackListContract";
+import { PolicyContract } from "../types/templates/PolicyManagerDataSource/PolicyContract";
+import { PriceToleranceContract } from "../types/templates/PolicyManagerDataSource/PriceToleranceContract";
+import { MaxPositionsContract } from "../types/templates/PolicyManagerDataSource/MaxPositionsContract";
+import { MaxConcentrationContract } from "../types/templates/PolicyManagerDataSource/MaxConcentrationContract";
+import { AssetWhiteListContract } from "../types/templates/PolicyManagerDataSource/AssetWhiteListContract";
+import { AssetBlackListContract } from "../types/templates/PolicyManagerDataSource/AssetBlackListContract";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleRegistration(event: Registration): void {

--- a/src/mappings/PolicyManagerFactory.ts
+++ b/src/mappings/PolicyManagerFactory.ts
@@ -1,4 +1,4 @@
-import { PolicyManagerDataSource } from "../types/PolicyManagerFactoryDataSource/templates";
+import { PolicyManagerDataSource } from "../types/templates";
 import { NewInstance } from "../types/PolicyManagerFactoryDataSource/PolicyManagerFactoryContract";
 import { PolicyManager } from "../types/schema";
 import { saveContract } from "./utils/saveContract";

--- a/src/mappings/PolicyManagerFactory.ts
+++ b/src/mappings/PolicyManagerFactory.ts
@@ -2,7 +2,6 @@ import { PolicyManagerDataSource } from "../types/templates";
 import { NewInstance } from "../types/PolicyManagerFactoryDataSource/PolicyManagerFactoryContract";
 import { PolicyManager } from "../types/schema";
 import { saveContract } from "./utils/saveContract";
-import { log, BigInt } from "@graphprotocol/graph-ts";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleNewInstance(event: NewInstance): void {

--- a/src/mappings/PriceSource.ts
+++ b/src/mappings/PriceSource.ts
@@ -37,10 +37,6 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
   let prices = event.params.price;
   let tokens = event.params.token;
 
-  if (!prices || !tokens) {
-    return;
-  }
-
   // AssetPriceUpdate entity groups all asset prices belonging to one timestamp
   let priceUpdate = new AssetPriceUpdate(event.block.timestamp.toString());
   priceUpdate.timestamp = event.block.timestamp;
@@ -55,6 +51,7 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
 
   let numberOfAssets = 0;
   let invalidPrices = 0;
+
   for (let i: i32 = 0; i < prices.length; i++) {
     let asset = Asset.load(tokens[i].toHex());
     if (!asset) {
@@ -64,6 +61,7 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
     // identify invalid prices
     // (they are set to 0 by the contract event emitter)
     let priceValid = true;
+
     if (prices[i].isZero()) {
       priceValid = false;
       invalidPrices = invalidPrices + 1;
@@ -102,36 +100,22 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
   if (!registryAddress) {
     return;
   }
+
   let registryEntity = Registry.load(registryAddress);
   if (!registryEntity) {
     return;
   }
 
   let versions = registryEntity.versions;
-  if (!versions) {
-    return;
-  }
-
-  // let registryContract = RegistryContract.bind(registryAddress);
-  // let versions = registryContract.getRegisteredVersions();
 
   let melonNetworkGav = BigInt.fromI32(0);
   let melonNetworkValidGav = true;
 
   for (let i: i32 = 0; i < versions.length; i++) {
-    let version = Version.load((versions as string[])[i]);
-    if (!version) {
-      return;
-    }
-
+    let version = Version.load(versions[i]) as Version;
     let funds = version.funds;
-    if (!funds) {
-      return;
-    }
-
-    // loop through all funds
-    for (let j: i32 = 0; j <= funds.length; j++) {
-      let fundAddress = (funds as string[])[i];
+    for (let j: i32 = 0; j < funds.length; j++) {
+      let fundAddress = funds[j];
       let fund = Fund.load(fundAddress);
 
       if (!fund) {
@@ -260,15 +244,7 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
       fund.save();
 
       // valuations for individual investments / investors
-      // let participationAddress = Address.fromString(fund.participation);
-      // let participationContract = ParticipationContract.bind(
-      //   participationAddress
-      // );
-
       let fundInvestments = fund.investments;
-
-      // TODO: from store!
-      // let historicalInvestors = participationContract.getHistoricalInvestors();
       for (let l: i32 = 0; l < fundInvestments.length; l++) {
         let investor = fundInvestments[l];
         let investment = investmentEntity(

--- a/src/mappings/PriceSource.ts
+++ b/src/mappings/PriceSource.ts
@@ -1,8 +1,5 @@
-import { Address, BigInt, TypedMap, log } from "@graphprotocol/graph-ts";
-import {
-  PriceSourceContract,
-  PriceUpdate
-} from "../types/PriceSourceDataSource/PriceSourceContract";
+import { Address, BigInt, TypedMap } from "@graphprotocol/graph-ts";
+import { PriceUpdate } from "../types/PriceSourceDataSource/PriceSourceContract";
 import {
   Fund,
   Asset,
@@ -97,8 +94,7 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
   state.save();
 
   // update values for all funds in all deployed versions
-  let priceSourceContract = PriceSourceContract.bind(event.address);
-  let registryAddress = priceSourceContract.REGISTRY();
+  let registryAddress = Address.fromString(state.registry as string);
 
   let registryContract = RegistryContract.bind(registryAddress);
   let versions = registryContract.getRegisteredVersions();
@@ -137,7 +133,8 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
     // loop through all funds
     for (let j: i32 = 0; j <= lastFundId.toI32(); j++) {
       let fundAddress = versionContract.getFundById(BigInt.fromI32(j)).toHex();
-      let fund = Fund.load(fundAddress) as Fund;
+      let fund = Fund.load(fundAddress);
+
       if (!fund) {
         continue;
       }

--- a/src/mappings/PriceSource.ts
+++ b/src/mappings/PriceSource.ts
@@ -107,7 +107,7 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
   let melonNetworkValidGav = true;
 
   for (let i: i32 = 0; i < versions.length; i++) {
-    // Don't run for early trial versions (which contain no funds)
+    // Don't run for early trial versions
     if (
       versions[i].toHex() ==
         Address.fromString(

--- a/src/mappings/PriceSource.ts
+++ b/src/mappings/PriceSource.ts
@@ -246,7 +246,7 @@ export function _handlePriceUpdate(event: PriceUpdate): void {
       // valuations for individual investments / investors
       let fundInvestments = fund.investments;
       for (let l: i32 = 0; l < fundInvestments.length; l++) {
-        let investor = fundInvestments[l];
+        let investor = fundInvestments[l].slice(0, 42);
         let investment = investmentEntity(
           investor,
           fundAddress,

--- a/src/mappings/Registry.ts
+++ b/src/mappings/Registry.ts
@@ -296,6 +296,10 @@ export function handleMlnTokenChange(event: MlnTokenChange): void {
     event.block.timestamp,
     event.address.toHex()
   );
+
+  let state = currentState();
+  state.mlnToken = event.address.toHex();
+  state.save();
 }
 
 export function handleNativeAssetChange(event: NativeAssetChange): void {

--- a/src/mappings/Registry.ts
+++ b/src/mappings/Registry.ts
@@ -59,6 +59,18 @@ export function handleLogSetOwner(event: LogSetOwner): void {
 }
 
 export function handleVersionRegistration(event: VersionRegistration): void {
+  // skip two version deployed before going live
+  if (
+    event.params.version.toHex() ==
+      Address.fromString(
+        "0x07ed984b46ff6789ba30b75b5f4690b9f15464d4"
+      ).toHex() ||
+    event.params.version.toHex() ==
+      Address.fromString("0xf1d376db5ed16d183a962eaa719a58773fba5dff").toHex()
+  ) {
+    return;
+  }
+
   VersionDataSource.create(event.params.version);
 
   let id = event.params.version.toHex();

--- a/src/mappings/Registry.ts
+++ b/src/mappings/Registry.ts
@@ -32,21 +32,7 @@ import {
 import { saveContract } from "./utils/saveContract";
 import { PriceSourceChange } from "../types/PriceSourceDataSource/RegistryContract";
 import { currentState } from "./utils/currentState";
-
-function engineEntity(address: Address, registry: Address): Engine {
-  let id = address.toHex();
-  let engine = Engine.load(id);
-
-  if (!engine) {
-    engine = new Engine(id);
-    engine.registry = registry.toHex();
-    engine.save();
-  }
-
-  return engine as Engine;
-}
-
-//
+import { engineEntity } from "./entities/engineEntity";
 
 export function handleLogSetOwner(event: LogSetOwner): void {
   let registry = new Registry(event.address.toHex());
@@ -282,7 +268,10 @@ export function handleEngineChange(event: EngineChange): void {
   }
 
   EngineDataSource.create(event.params.engine);
-  let engine = engineEntity(event.params.engine, event.address);
+  let engine = engineEntity(event.params.engine.toHex());
+  engine.registry = event.address.toHex();
+  engine.save();
+
   registry.engine = engine.id;
   registry.save();
 

--- a/src/mappings/Registry.ts
+++ b/src/mappings/Registry.ts
@@ -39,6 +39,7 @@ export function handleLogSetOwner(event: LogSetOwner): void {
   registry.owner = event.params.owner.toHex();
   registry.exchangeAdapters = [];
   registry.assets = [];
+  registry.versions = [];
   registry.save();
 
   let state = currentState();
@@ -63,22 +64,23 @@ export function handleVersionRegistration(event: VersionRegistration): void {
     event.params.version
   );
 
-  let version = Version.load(id);
+  let version = new Version(id);
+  version.registry = event.address.toHex();
+  version.name = versionInformation.value1.toHexString();
+  version.funds = [];
+  version.save();
 
-  if (!version) {
-    version = new Version(id);
-    version.registry = event.address.toHex();
-    version.name = versionInformation.value1.toHexString();
-    version.save();
+  let registry = Registry.load(event.address.toHex()) as Registry;
+  registry.versions = registry.versions.concat([version.id]);
+  registry.save();
 
-    saveContract(
-      id,
-      "Version",
-      version.name,
-      event.block.timestamp,
-      event.address.toHex()
-    );
-  }
+  saveContract(
+    id,
+    "Version",
+    version.name,
+    event.block.timestamp,
+    event.address.toHex()
+  );
 }
 
 function assetNameFromAddress(address: Address): string {

--- a/src/mappings/Registry.ts
+++ b/src/mappings/Registry.ts
@@ -1,5 +1,9 @@
 import { Address } from "@graphprotocol/graph-ts";
-import { EngineDataSource, PriceSourceDataSource } from "../types/templates";
+import {
+  EngineDataSource,
+  PriceSourceDataSource,
+  VersionDataSource
+} from "../types/templates";
 import {
   Registry,
   Version,
@@ -55,6 +59,8 @@ export function handleLogSetOwner(event: LogSetOwner): void {
 }
 
 export function handleVersionRegistration(event: VersionRegistration): void {
+  VersionDataSource.create(event.params.version);
+
   let id = event.params.version.toHex();
 
   let registryContract = RegistryContract.bind(event.address);

--- a/src/mappings/Registry.ts
+++ b/src/mappings/Registry.ts
@@ -1,4 +1,5 @@
-import { Address, log, BigInt } from "@graphprotocol/graph-ts";
+import { Address } from "@graphprotocol/graph-ts";
+import { EngineDataSource, PriceSourceDataSource } from "../types/templates";
 import {
   Registry,
   Version,
@@ -250,6 +251,8 @@ export function handleExchangeAdapterRemoval(
 }
 
 export function handleEngineChange(event: EngineChange): void {
+  EngineDataSource.create(event.params.engine);
+
   let registry = Registry.load(event.address.toHex()) as Registry;
   let engine = engineEntity(event.params.engine, event.address);
   registry.engine = engine.id;
@@ -269,6 +272,8 @@ export function handleEngineChange(event: EngineChange): void {
 }
 
 export function handlePriceSourceChange(event: PriceSourceChange): void {
+  PriceSourceDataSource.create(event.params.priceSource);
+
   let priceSource = new PriceSource(event.params.priceSource.toHex());
   priceSource.registry = event.address.toHex();
   priceSource.save();
@@ -298,7 +303,7 @@ export function handleMlnTokenChange(event: MlnTokenChange): void {
   );
 
   let state = currentState();
-  state.mlnToken = event.address.toHex();
+  state.mlnToken = event.params.mlnToken.toHex();
   state.save();
 }
 

--- a/src/mappings/Registry.ts
+++ b/src/mappings/Registry.ts
@@ -35,11 +35,15 @@ import { currentState } from "./utils/currentState";
 import { engineEntity } from "./entities/engineEntity";
 
 export function handleLogSetOwner(event: LogSetOwner): void {
-  let registry = new Registry(event.address.toHex());
+  let registry = Registry.load(event.address.toHex());
+  if (!registry) {
+    registry = new Registry(event.address.toHex());
+
+    registry.exchangeAdapters = [];
+    registry.assets = [];
+    registry.versions = [];
+  }
   registry.owner = event.params.owner.toHex();
-  registry.exchangeAdapters = [];
-  registry.assets = [];
-  registry.versions = [];
   registry.save();
 
   let state = currentState();

--- a/src/mappings/Shares.ts
+++ b/src/mappings/Shares.ts
@@ -1,4 +1,7 @@
-import { Approval, Transfer } from "../types/SharesFactoryDataSource/templates/SharesDataSource/SharesContract";
+import {
+  Approval,
+  Transfer
+} from "../types/templates/SharesDataSource/SharesContract";
 
 export function handleApproval(event: Approval): void {
   // TODO

--- a/src/mappings/SharesFactory.ts
+++ b/src/mappings/SharesFactory.ts
@@ -1,4 +1,4 @@
-import { SharesDataSource } from "../types/SharesFactoryDataSource/templates";
+import { SharesDataSource } from "../types/templates";
 import { NewInstance } from "../types/SharesFactoryDataSource/SharesFactoryContract";
 import { Share } from "../types/schema";
 import { saveContract } from "./utils/saveContract";

--- a/src/mappings/Trading.ts
+++ b/src/mappings/Trading.ts
@@ -1,16 +1,16 @@
 import {
   ExchangeMethodCall,
   TradingContract
-} from "../types/TradingFactoryDataSource/templates/TradingDataSource/TradingContract";
+} from "../types/templates/TradingDataSource/TradingContract";
 import {
   ExchangeMethodCall as ExchangeMethodCallEntity,
   FundHoldingsHistory,
   FundCalculationsHistory,
   Fund
 } from "../types/schema";
-import { AccountingContract } from "../types/TradingFactoryDataSource/templates/TradingDataSource/AccountingContract";
-import { PriceSourceContract } from "../types/TradingFactoryDataSource/templates/TradingDataSource/PriceSourceContract";
-import { SharesContract } from "../types/TradingFactoryDataSource/templates/TradingDataSource/SharesContract";
+import { AccountingContract } from "../types/templates/TradingDataSource/AccountingContract";
+import { PriceSourceContract } from "../types/templates/TradingDataSource/PriceSourceContract";
+import { SharesContract } from "../types/templates/TradingDataSource/SharesContract";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleExchangeMethodCall(event: ExchangeMethodCall): void {

--- a/src/mappings/Trading.ts
+++ b/src/mappings/Trading.ts
@@ -1,7 +1,4 @@
-import {
-  ExchangeMethodCall,
-  TradingContract
-} from "../types/templates/TradingDataSource/TradingContract";
+import { ExchangeMethodCall } from "../types/templates/TradingDataSource/TradingContract";
 import {
   ExchangeMethodCall as ExchangeMethodCallEntity,
   FundHoldingsHistory,

--- a/src/mappings/TradingFactory.ts
+++ b/src/mappings/TradingFactory.ts
@@ -1,4 +1,4 @@
-import { TradingDataSource } from "../types/TradingFactoryDataSource/templates";
+import { TradingDataSource } from "../types/templates";
 import { NewInstance } from "../types/TradingFactoryDataSource/TradingFactoryContract";
 import { Trading } from "../types/schema";
 import { saveContract } from "./utils/saveContract";

--- a/src/mappings/TradingFactory.ts
+++ b/src/mappings/TradingFactory.ts
@@ -2,7 +2,6 @@ import { TradingDataSource } from "../types/templates";
 import { NewInstance } from "../types/TradingFactoryDataSource/TradingFactoryContract";
 import { Trading } from "../types/schema";
 import { saveContract } from "./utils/saveContract";
-import { BigInt } from "@graphprotocol/graph-ts";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleNewInstance(event: NewInstance): void {

--- a/src/mappings/TradingFactoryV101.ts
+++ b/src/mappings/TradingFactoryV101.ts
@@ -1,8 +1,7 @@
 import { Trading } from "../types/schema";
 import { saveContract } from "./utils/saveContract";
 import { NewInstance } from "../types/TradingFactoryDataSourceV101/TradingFactoryContractV101";
-import { TradingDataSourceV101 } from "../types/TradingFactoryDataSourceV101/templates";
-import { BigInt, log } from "@graphprotocol/graph-ts";
+import { TradingDataSourceV101 } from "../types/templates";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleNewInstance(event: NewInstance): void {

--- a/src/mappings/TradingV101.ts
+++ b/src/mappings/TradingV101.ts
@@ -1,16 +1,16 @@
 import {
   ExchangeMethodCall,
   TradingContractV101
-} from "../types/TradingFactoryDataSourceV101/templates/TradingDataSourceV101/TradingContractV101";
+} from "../types/templates/TradingDataSourceV101/TradingContractV101";
 import {
   ExchangeMethodCall as ExchangeMethodCallEntity,
   FundCalculationsHistory,
   FundHoldingsHistory,
   Fund
 } from "../types/schema";
-import { AccountingContract } from "../types/TradingFactoryDataSourceV101/templates/TradingDataSourceV101/AccountingContract";
-import { PriceSourceContract } from "../types/TradingFactoryDataSourceV101/templates/TradingDataSourceV101/PriceSourceContract";
-import { SharesContract } from "../types/TradingFactoryDataSourceV101/templates/TradingDataSourceV101/SharesContract";
+import { AccountingContract } from "../types/templates/TradingDataSourceV101/AccountingContract";
+import { PriceSourceContract } from "../types/templates/TradingDataSourceV101/PriceSourceContract";
+import { SharesContract } from "../types/templates/TradingDataSourceV101/SharesContract";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleExchangeMethodCall(event: ExchangeMethodCall): void {

--- a/src/mappings/VaultFactory.ts
+++ b/src/mappings/VaultFactory.ts
@@ -1,4 +1,4 @@
-import { VaultDataSource } from "../types/VaultFactoryDataSource/templates";
+import { VaultDataSource } from "../types/templates";
 import { NewInstance } from "../types/VaultFactoryDataSource/VaultFactoryContract";
 import { Vault } from "../types/schema";
 import { saveContract } from "./utils/saveContract";

--- a/src/mappings/Version.ts
+++ b/src/mappings/Version.ts
@@ -4,7 +4,8 @@ import {
   Fund,
   FundCount,
   FundManager,
-  FundCalculationsHistory
+  FundCalculationsHistory,
+  Version
 } from "../types/schema";
 import { hexToAscii } from "./utils/hexToAscii";
 import { HubContract } from "../types/VersionDataSource/HubContract";
@@ -50,7 +51,12 @@ export function handleNewFund(event: NewFund): void {
   fund.registry = addresses[8];
   fund.version = addresses[9];
   fund.engine = addresses[10];
+  fund.investments = [];
   fund.save();
+
+  let version = Version.load(event.address.toHex()) as Version;
+  version.funds = version.funds.concat([fund.id]);
+  version.save();
 
   saveContract(hub, "Hub", fund.name, event.block.timestamp, addresses[9]);
 

--- a/src/mappings/Version.ts
+++ b/src/mappings/Version.ts
@@ -1,5 +1,5 @@
 import { NewFund } from "../types/VersionDataSource/VersionContract";
-import { HubDataSource } from "../types/VersionDataSource/templates";
+import { HubDataSource } from "../types/templates";
 import {
   Fund,
   FundCount,

--- a/src/mappings/Version.ts
+++ b/src/mappings/Version.ts
@@ -46,6 +46,7 @@ export function handleNewFund(event: NewFund): void {
   fund.share = addresses[4];
   fund.trading = addresses[5];
   fund.vault = addresses[6];
+  fund.priceSource = addresses[7];
   fund.registry = addresses[8];
   fund.version = addresses[9];
   fund.engine = addresses[10];

--- a/src/mappings/Version.ts
+++ b/src/mappings/Version.ts
@@ -16,6 +16,11 @@ import { SharesContract } from "../types/VersionDataSource/SharesContract";
 import { saveEventHistory } from "./utils/saveEventHistory";
 
 export function handleNewFund(event: NewFund): void {
+  // ignore contracts created before go-live
+  if (event.block.number.toI32() < 7278341) {
+    return;
+  }
+
   HubDataSource.create(event.params.hub);
 
   let hub = event.params.hub.toHex();

--- a/src/mappings/entities/engineEntity.ts
+++ b/src/mappings/entities/engineEntity.ts
@@ -1,0 +1,26 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+
+import { Engine } from "../../types/schema";
+
+export function engineEntity(id: string): Engine {
+  let engine = Engine.load(id);
+
+  if (!engine) {
+    engine = new Engine(id);
+    engine.registry = "";
+    engine.amguPrice = BigInt.fromI32(0);
+    engine.frozenEther = BigInt.fromI32(0);
+    engine.liquidEther = BigInt.fromI32(0);
+    engine.lastThaw = BigInt.fromI32(0);
+    engine.thawingDelay = BigInt.fromI32(0);
+    engine.totalEtherConsumed = BigInt.fromI32(0);
+    engine.totalAmguConsumed = BigInt.fromI32(0);
+    engine.totalMlnBurned = BigInt.fromI32(0);
+    engine.premiumPercent = BigInt.fromI32(0);
+    engine.mlnTotalSupply = BigInt.fromI32(0);
+    engine.lastUpdate = BigInt.fromI32(0);
+    engine.save();
+  }
+
+  return engine as Engine;
+}

--- a/src/mappings/entities/investmentEntity.ts
+++ b/src/mappings/entities/investmentEntity.ts
@@ -3,11 +3,11 @@ import { Investment } from "../../types/schema";
 import { investorEntity } from "./investorEntity";
 
 export function investmentEntity(
-  owner: Address,
-  fund: Address,
+  owner: string,
+  fund: string,
   createdAt: BigInt
 ): Investment {
-  let id = owner.toHex() + "/" + fund.toHex();
+  let id = owner + "/" + fund;
   let investment = Investment.load(id);
 
   if (!investment) {
@@ -16,7 +16,7 @@ export function investmentEntity(
     investment.shares = BigInt.fromI32(0);
     investment.gav = BigInt.fromI32(0);
     investment.nav = BigInt.fromI32(0);
-    investment.fund = fund.toHex();
+    investment.fund = fund;
     investment.owner = investorEntity(owner, createdAt).id;
     investment.save();
   }

--- a/src/mappings/entities/investmentEntity.ts
+++ b/src/mappings/entities/investmentEntity.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 import { Investment } from "../../types/schema";
 import { investorEntity } from "./investorEntity";
 

--- a/src/mappings/entities/investorEntity.ts
+++ b/src/mappings/entities/investorEntity.ts
@@ -1,8 +1,8 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { Investor } from "../../types/schema";
 
-export function investorEntity(address: Address, createdAt: BigInt): Investor {
-  let id = address.toHex();
+export function investorEntity(address: string, createdAt: BigInt): Investor {
+  let id = address;
   let investor = Investor.load(id);
 
   if (!investor) {

--- a/src/mappings/entities/investorValuationHistoryEntity.ts
+++ b/src/mappings/entities/investorValuationHistoryEntity.ts
@@ -3,10 +3,10 @@ import { InvestorValuationHistory } from "../../types/schema";
 import { investorEntity } from "./investorEntity";
 
 export function investorValuationHistoryEntity(
-  owner: Address,
+  owner: string,
   createdAt: BigInt
 ): InvestorValuationHistory {
-  let id = owner.toHex() + "/" + createdAt.toString();
+  let id = owner + "/" + createdAt.toString();
   let investorValuationHistory = InvestorValuationHistory.load(id);
 
   if (!investorValuationHistory) {

--- a/src/mappings/entities/investorValuationHistoryEntity.ts
+++ b/src/mappings/entities/investorValuationHistoryEntity.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 import { InvestorValuationHistory } from "../../types/schema";
 import { investorEntity } from "./investorEntity";
 

--- a/src/mappings/entities/networkAssetHistoryEntity.ts
+++ b/src/mappings/entities/networkAssetHistoryEntity.ts
@@ -1,6 +1,5 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { MelonNetworkAssetHistory } from "../../types/schema";
-import { investorEntity } from "./investorEntity";
 
 export function networkAssetHistoryEntity(
   asset: Address,

--- a/src/mappings/utils/currentState.ts
+++ b/src/mappings/utils/currentState.ts
@@ -12,6 +12,7 @@ export function currentState(): State {
     state.numberOfInvestors = BigInt.fromI32(0);
     state.timestamptNumberOfInvestors = BigInt.fromI32(0);
     state.lastEngineUpdate = BigInt.fromI32(0);
+    state.mlnToken = "";
     state.save();
   }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,4 @@
 {
   "extends": "../node_modules/assemblyscript/std/assembly.json",
-  "include": [
-    "./**/*.ts"
-  ]
+  "include": ["./**/*.ts"]
 }

--- a/subgraph.ash.kovan.yaml
+++ b/subgraph.ash.kovan.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.1
+specVersion: 0.0.2
 description: Melon protocol
 repository: https://github.com/melonproject/melon-subgraph
 schema:
@@ -15,9 +15,9 @@ dataSources:
   #
   - name: RegistryDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
-      address: "{{melonContracts.registry}}"
+      address: "0xb8acdbe95e9980fae93716eba27709bcf1765a12"
       abi: RegistryContract
     mapping:
       kind: ethereum/events
@@ -65,10 +65,10 @@ dataSources:
   #
   - name: AccountingFactoryDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: AccountingFactoryContract
-      address: "{{melonContracts.factories.accountingFactory}}"
+      address: "0x7a5610726e7108b00d7aec02d3fecf002bcb3b7f"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -88,10 +88,10 @@ dataSources:
 
   - name: FeeManagerFactoryDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: FeeManagerFactoryContract
-      address: "{{melonContracts.factories.feeManagerFactory}}"
+      address: "0x5c9da2aa2baf1d365463f6e3f207b7ba0fe422d1"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -108,10 +108,10 @@ dataSources:
 
   - name: ParticipationFactoryDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: ParticipationFactoryContract
-      address: "{{melonContracts.factories.participationFactory}}"
+      address: "0xc858bd40511fdf6afdf1653e15477c9ba7279058"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -129,10 +129,10 @@ dataSources:
 
   - name: PolicyManagerFactoryDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: PolicyManagerFactoryContract
-      address: "{{melonContracts.factories.policyManagerFactory}}"
+      address: "0x1c60cd02c5a824ce3c0c5a3dae6551fd748ebbb2"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -149,10 +149,10 @@ dataSources:
 
   - name: SharesFactoryDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: SharesFactoryContract
-      address: "{{melonContracts.factories.sharesFactory}}"
+      address: "0x68b80025ec4f99788aad08b259d671c8637bbee7"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -167,33 +167,33 @@ dataSources:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
 
-  - name: TradingFactoryDataSource
-    kind: ethereum/contract
-    network: "{{meta.network}}"
-    source:
-      abi: TradingFactoryContract
-      address: "{{melonContracts.factories.tradingFactory}}"
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/TradingFactory.ts
-      entities:
-        - Trading
-      abis:
-        - name: TradingFactoryContract
-          file: ./node_modules/@melonproject/protocol/out/TradingFactory.abi.json
-      eventHandlers:
-        - event: NewInstance(indexed address,indexed address,address[],address[],address)
-          handler: handleNewInstance
+  # - name: TradingFactoryDataSource
+  #   kind: ethereum/contract
+  #   network: "kovan"
+  #   source:
+  #     abi: TradingFactoryContract
+  #     address: "0xa9d2abf2107626cf8199a89f06a48b6b0653fc63"
+  #   mapping:
+  #     kind: ethereum/events
+  #     apiVersion: 0.0.3
+  #     language: wasm/assemblyscript
+  #     file: ./src/mappings/TradingFactory.ts
+  #     entities:
+  #       - Trading
+  #     abis:
+  #       - name: TradingFactoryContract
+  #         file: ./node_modules/@melonproject/protocol/out/TradingFactory.abi.json
+  #     eventHandlers:
+  #       - event: NewInstance(indexed address,indexed address,address[],address[],address)
+  #         handler: handleNewInstance
 
-    # old trading factory
+  # old trading factory
   - name: TradingFactoryDataSourceV101
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: TradingFactoryContractV101
-      address: "0xe2c3fe25336eE3bD71dcA3380b7423a3bDef3d8C"
+      address: "0xa9d2abf2107626cf8199a89f06a48b6b0653fc63"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -210,10 +210,10 @@ dataSources:
 
   - name: VaultFactoryDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: VaultFactoryContract
-      address: "{{melonContracts.factories.vaultFactory}}"
+      address: "0xb872553b0c5d8ee3ddb7eb48dd955a9ceac3cd76"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -239,7 +239,7 @@ templates:
   #
   - name: VersionDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: VersionContract
     mapping:
@@ -267,7 +267,7 @@ templates:
 
   - name: EngineDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: EngineContract
     mapping:
@@ -297,7 +297,7 @@ templates:
 
   - name: PriceSourceDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: PriceSourceContract
     mapping:
@@ -342,7 +342,7 @@ templates:
   #
   - name: HubDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: HubContract
     mapping:
@@ -363,7 +363,7 @@ templates:
 
   - name: AccountingDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: AccountingContract
     mapping:
@@ -384,7 +384,7 @@ templates:
 
   - name: FeeManagerDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: FeeManagerContract
     mapping:
@@ -416,7 +416,7 @@ templates:
 
   - name: ParticipationDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: ParticipationContract
     mapping:
@@ -462,7 +462,7 @@ templates:
 
   - name: PolicyManagerDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: PolicyManagerContract
     mapping:
@@ -494,7 +494,7 @@ templates:
 
   - name: SharesDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: SharesContract
     mapping:
@@ -516,7 +516,7 @@ templates:
   # current trading contract
   - name: TradingDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: TradingContract
     mapping:
@@ -542,7 +542,7 @@ templates:
   # old trading contract
   - name: TradingDataSourceV101
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: TradingContractV101
     mapping:
@@ -567,7 +567,7 @@ templates:
 
   - name: VaultDataSource
     kind: ethereum/contract
-    network: "{{meta.network}}"
+    network: "kovan"
     source:
       abi: VaultContract
     mapping:

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -4,7 +4,15 @@ repository: https://github.com/melonproject/melon-subgraph
 schema:
   file: ./schema.graphql
 
+###############################################################################
+#
+# Contracts with fixed addresses
+#
+###############################################################################
 dataSources:
+  #
+  # Registry contract as main entry point
+  #
   - name: RegistryDataSource
     kind: ethereum/contract
     network: "{{meta.network}}"
@@ -52,140 +60,9 @@ dataSources:
         - event: LogSetOwner(indexed address)
           handler: handleLogSetOwner
 
-  - name: EngineDataSource
-    kind: ethereum/contract
-    network: "{{meta.network}}"
-    source:
-      address: "{{melonContracts.engine}}"
-      abi: EngineContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/Engine.ts
-      entities:
-        - Engine
-        - Registry
-      abis:
-        - name: EngineContract
-          file: ./node_modules/@melonproject/protocol/out/Engine.abi.json
-        - name: MlnContract
-          file: ./node_modules/@melonproject/protocol/out/PreminedToken.abi.json
-      eventHandlers:
-        - event: SetAmguPrice(uint256)
-          handler: handleSetAmguPrice
-        - event: RegistryChange(address)
-          handler: handleRegistryChange
-        - event: AmguPaid(uint256)
-          handler: handleAmguPaid
-        - event: Thaw(uint256)
-          handler: handleThaw
-        - event: Burn(uint256)
-          handler: handleBurn
-
-  - name: PriceSourceDataSource
-    kind: ethereum/contract
-    network: "{{meta.network}}"
-    source:
-      address: "{{melonContracts.priceSource}}"
-      abi: PriceSourceContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/PriceSource.ts
-      entities:
-        - State
-        - Asset
-        - AssetPriceUpdate
-        - Fund
-        - FundCalculationsHistory
-        - NetworkValue
-        - Investment
-        - InvestmentValuationHistory
-        - Investor
-        - InvestorValuationHistory
-      abis:
-        - name: PriceSourceContract
-          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-        - name: RegistryContract
-          file: ./node_modules/@melonproject/protocol/out/Registry.abi.json
-        - name: VersionContract
-          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
-        - name: HubContract
-          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-        - name: AccountingContract
-          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-        - name: SharesContract
-          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-        - name: ParticipationContract
-          file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
-        - name: FeeManagerContract
-          file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
-      eventHandlers:
-        - event: PriceUpdate(address[],uint256[])
-          handler: handlePriceUpdate
-
-  # current version contract
-  - name: VersionDataSource
-    kind: ethereum/contract
-    network: "{{meta.network}}"
-    source:
-      address: "{{melonContracts.version}}"
-      abi: VersionContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/Version.ts
-      entities:
-        - Fund
-        - FundCount
-        - State
-        - FundCalculationsHistory
-      abis:
-        - name: VersionContract
-          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
-        - name: HubContract
-          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-        - name: AccountingContract
-          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-        - name: SharesContract
-          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-      eventHandlers:
-        - event: NewFund(indexed address,indexed address,address[12])
-          handler: handleNewFund
-
-  # old Version Contract (first deployment)
-  - name: VersionDataSource
-    kind: ethereum/contract
-    network: "{{meta.network}}"
-    source:
-      address: "0xCB6c6Bdf0AA4cF0188518783b871931EFB64248f"
-      abi: VersionContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/Version.ts
-      entities:
-        - Fund
-        - FundCount
-        - State
-        - FundCalculationsHistory
-      abis:
-        - name: VersionContract
-          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
-        - name: HubContract
-          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-        - name: AccountingContract
-          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-        - name: SharesContract
-          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-      eventHandlers:
-        - event: NewFund(indexed address,indexed address,address[12])
-          handler: handleNewFund
-
+  #
+  # Factory contracts for fund spokes
+  #
   - name: AccountingFactoryDataSource
     kind: ethereum/contract
     network: "{{meta.network}}"
@@ -290,7 +167,6 @@ dataSources:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
 
-  # current trading factory
   - name: TradingFactoryDataSource
     kind: ethereum/contract
     network: "{{meta.network}}"
@@ -352,11 +228,118 @@ dataSources:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
 
+###############################################################################
 #
-# TEMPLATES
+# Contracts with dynamically set addresses
 #
-#
+###############################################################################
 templates:
+  #
+  # Infrastructure templates
+  #
+  - name: VersionDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: VersionContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Version.ts
+      entities:
+        - Fund
+        - FundCount
+        - State
+        - FundCalculationsHistory
+      abis:
+        - name: VersionContract
+          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: NewFund(indexed address,indexed address,address[12])
+          handler: handleNewFund
+
+  - name: EngineDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: EngineContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Engine.ts
+      entities:
+        - Engine
+        - Registry
+      abis:
+        - name: EngineContract
+          file: ./node_modules/@melonproject/protocol/out/Engine.abi.json
+        - name: MlnContract
+          file: ./node_modules/@melonproject/protocol/out/PreminedToken.abi.json
+      eventHandlers:
+        - event: SetAmguPrice(uint256)
+          handler: handleSetAmguPrice
+        - event: RegistryChange(address)
+          handler: handleRegistryChange
+        - event: AmguPaid(uint256)
+          handler: handleAmguPaid
+        - event: Thaw(uint256)
+          handler: handleThaw
+        - event: Burn(uint256)
+          handler: handleBurn
+
+  - name: PriceSourceDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: PriceSourceContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/PriceSource.ts
+      entities:
+        - State
+        - Asset
+        - AssetPriceUpdate
+        - Fund
+        - FundCalculationsHistory
+        - NetworkValue
+        - Investment
+        - InvestmentValuationHistory
+        - Investor
+        - InvestorValuationHistory
+      abis:
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+        - name: RegistryContract
+          file: ./node_modules/@melonproject/protocol/out/Registry.abi.json
+        - name: VersionContract
+          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+        - name: ParticipationContract
+          file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
+        - name: FeeManagerContract
+          file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
+      eventHandlers:
+        - event: PriceUpdate(address[],uint256[])
+          handler: handlePriceUpdate
+
+  #
+  # Fund hub/spokes templates
+  #
   - name: HubDataSource
     kind: ethereum/contract
     network: "{{meta.network}}"

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -3,12 +3,13 @@ description: Melon protocol
 repository: https://github.com/melonproject/melon-subgraph
 schema:
   file: ./schema.graphql
+
 dataSources:
   - name: RegistryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
-      address: '{{melonContracts.registry}}'
+      address: "{{melonContracts.registry}}"
       abi: RegistryContract
     mapping:
       kind: ethereum/events
@@ -48,14 +49,14 @@ dataSources:
           handler: handleNativeAssetChange
         - event: MGMChange(indexed address)
           handler: handleMGMChange
-        - event: LogSetOwner(address)
+        - event: LogSetOwner(indexed address)
           handler: handleLogSetOwner
-  
+
   - name: EngineDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
-      address: '{{melonContracts.engine}}'
+      address: "{{melonContracts.engine}}"
       abi: EngineContract
     mapping:
       kind: ethereum/events
@@ -84,9 +85,9 @@ dataSources:
 
   - name: PriceSourceDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
-      address: '{{melonContracts.priceSource}}'
+      address: "{{melonContracts.priceSource}}"
       abi: PriceSourceContract
     mapping:
       kind: ethereum/events
@@ -125,12 +126,12 @@ dataSources:
         - event: PriceUpdate(address[],uint256[])
           handler: handlePriceUpdate
 
-  # current version contract 
+  # current version contract
   - name: VersionDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
-      address: '{{melonContracts.version}}'
+      address: "{{melonContracts.version}}"
       abi: VersionContract
     mapping:
       kind: ethereum/events
@@ -154,36 +155,13 @@ dataSources:
       eventHandlers:
         - event: NewFund(indexed address,indexed address,address[12])
           handler: handleNewFund
-    templates:
-      - name: HubDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: HubContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Hub.ts
-          entities:
-            - Fund
-            - FundCount
-            - State
-          abis:
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-          eventHandlers:
-            - event: LogSetOwner(address)
-              handler: handleLogSetOwner
-            - event: FundShutDown()
-              handler: handleFundShutDown
 
   # old Version Contract (first deployment)
   - name: VersionDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
-      address: '0xCB6c6Bdf0AA4cF0188518783b871931EFB64248f'
+      address: "0xCB6c6Bdf0AA4cF0188518783b871931EFB64248f"
       abi: VersionContract
     mapping:
       kind: ethereum/events
@@ -207,35 +185,13 @@ dataSources:
       eventHandlers:
         - event: NewFund(indexed address,indexed address,address[12])
           handler: handleNewFund
-    templates:
-      - name: HubDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: HubContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Hub.ts
-          entities:
-            - Fund
-            - FundCount
-            - State
-          abis:
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-          eventHandlers:
-            - event: FundShutDown()
-              handler: handleFundShutDown
 
-  
   - name: AccountingFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: AccountingFactoryContract
-      address: '{{melonContracts.factories.accountingFactory}}'
+      address: "{{melonContracts.factories.accountingFactory}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -252,34 +208,13 @@ dataSources:
           handler: handleNewInstance
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance1
-    templates:
-      - name: AccountingDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: AccountingContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Accounting.ts
-          entities:
-            - Accounting
-          abis:
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-          eventHandlers:
-            - event: AssetAddition(indexed address)
-              handler: handleAssetAddition
-            - event: AssetRemoval(indexed address)
-              handler: handleAssetRemoval
 
   - name: FeeManagerFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: FeeManagerFactoryContract
-      address: '{{melonContracts.factories.feeManagerFactory}}'
+      address: "{{melonContracts.factories.feeManagerFactory}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -293,45 +228,13 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: FeeManagerDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: FeeManagerContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/FeeManager.ts
-          entities:
-            - FeeManager
-            - ManagementFee
-            - PerformanceFee
-            - Fund
-            - Investment
-            - Investor
-          abis:
-            - name: FeeManagerContract
-              file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
-            - name: ManagementFeeContract
-              file: ./node_modules/@melonproject/protocol/out/ManagementFee.abi.json   
-            - name: PerformanceFeeContract
-              file: ./node_modules/@melonproject/protocol/out/PerformanceFee.abi.json  
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json  
-          eventHandlers:
-            - event: FeeRegistration(address)
-              handler: handleFeeRegistration
-            - event: FeeReward(uint256)
-              handler: handleFeeReward
 
   - name: ParticipationFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: ParticipationFactoryContract
-      address: '{{melonContracts.factories.participationFactory}}'
+      address: "{{melonContracts.factories.participationFactory}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -346,60 +249,13 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address,address[],address)
           handler: handleNewInstance
-    templates:
-      - name: ParticipationDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: ParticipationContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Participation.ts
-          entities:
-            - Asset
-            - Participation
-            - Investor
-            - Investment
-            - InvestmentRequest
-            - Fund
-            - InvestorCount
-            - State
-            - InvestmentHistory
-            - FundHoldingsHistory
-          abis:
-            - name: ParticipationContract
-              file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-            - name: PriceSourceContract
-              file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-          eventHandlers:
-            - event: InvestmentRequest(indexed address,indexed address,uint256,uint256)
-              handler: handleInvestmentRequest
-            - event: RequestExecution(indexed address,indexed address,indexed address,uint256,uint256)
-              handler: handleRequestExecution
-            - event: CancelRequest(indexed address)
-              handler: handleCancelRequest
-            - event: Redemption(indexed address,address[],uint256[],uint256)
-              handler: handleRedemption
-            - event: EnableInvestment(address[])
-              handler: handleEnableInvestment
-            - event: DisableInvestment(address[])
-              handler: handleDisableInvestment
-
 
   - name: PolicyManagerFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: PolicyManagerFactoryContract
-      address: '{{melonContracts.factories.policyManagerFactory}}'
+      address: "{{melonContracts.factories.policyManagerFactory}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -413,45 +269,13 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: PolicyManagerDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: PolicyManagerContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/PolicyManager.ts
-          entities:
-            - PolicyManager
-            - Policy
-          abis:
-            - name: PolicyManagerContract
-              file: ./node_modules/@melonproject/protocol/out/PolicyManager.abi.json
-            - name: PolicyContract
-              file: ./node_modules/@melonproject/protocol/out/Policy.abi.json
-            - name: AssetBlackListContract
-              file: ./node_modules/@melonproject/protocol/out/AssetBlackList.abi.json
-            - name: AssetWhiteListContract
-              file: ./node_modules/@melonproject/protocol/out/AssetWhiteList.abi.json
-            - name: MaxConcentrationContract
-              file: ./node_modules/@melonproject/protocol/out/MaxConcentration.abi.json
-            - name: MaxPositionsContract
-              file: ./node_modules/@melonproject/protocol/out/MaxPositions.abi.json
-            - name: PriceToleranceContract
-              file: ./node_modules/@melonproject/protocol/out/PriceTolerance.abi.json
-          eventHandlers:
-            - event: Registration(indexed bytes4,uint8,indexed address)
-              handler: handleRegistration
 
   - name: SharesFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: SharesFactoryContract
-      address: '{{melonContracts.factories.sharesFactory}}'
+      address: "{{melonContracts.factories.sharesFactory}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -465,35 +289,14 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: SharesDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: SharesContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Shares.ts
-          entities:
-            - Shares
-          abis:
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-          eventHandlers:
-            - event: Approval(indexed address,indexed address,uint256)
-              handler: handleApproval
-            - event: Transfer(indexed address,indexed address,uint256)
-              handler: handleTransfer
 
   # current trading factory
   - name: TradingFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: TradingFactoryContract
-      address: '{{melonContracts.factories.tradingFactory}}'
+      address: "{{melonContracts.factories.tradingFactory}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -507,39 +310,14 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address,address[],address[],address)
           handler: handleNewInstance
-    templates:
-      - name: TradingDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: TradingContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Trading.ts
-          entities:
-            - Trading
-          abis:
-            - name: TradingContract
-              file: ./node_modules/@melonproject/protocol/out/Trading.abi.json
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-            - name: PriceSourceContract
-              file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-          eventHandlers:
-            - event: ExchangeMethodCall(indexed address,indexed string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
-              handler: handleExchangeMethodCall
 
-   # old trading factory
+    # old trading factory
   - name: TradingFactoryDataSourceV101
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: TradingFactoryContractV101
-      address: '0xe2c3fe25336eE3bD71dcA3380b7423a3bDef3d8C'
+      address: "0xe2c3fe25336eE3bD71dcA3380b7423a3bDef3d8C"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -553,38 +331,13 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address,address[],address[],bool[],address)
           handler: handleNewInstance
-    templates:
-      - name: TradingDataSourceV101
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: TradingContractV101
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/TradingV101.ts
-          entities:
-            - Trading
-          abis:
-            - name: TradingContractV101
-              file: ./node_modules/@melonproject/protocol-v.1.0.1/out/Trading.abi.json
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-            - name: PriceSourceContract
-              file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-          eventHandlers:
-            - event: ExchangeMethodCall(indexed address,indexed string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
-              handler: handleExchangeMethodCall
 
   - name: VaultFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "{{meta.network}}"
     source:
       abi: VaultFactoryContract
-      address: '{{melonContracts.factories.vaultFactory}}'
+      address: "{{melonContracts.factories.vaultFactory}}"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -598,19 +351,251 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: VaultDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: VaultContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Vault.ts
-          entities:
-            - Vault
-          abis:
-            - name: VaultContract
-              file: ./node_modules/@melonproject/protocol/out/Vault.abi.json
+
+#
+# TEMPLATES
+#
+#
+templates:
+  - name: HubDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: HubContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Hub.ts
+      entities:
+        - Fund
+        - FundCount
+        - State
+      abis:
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+      eventHandlers:
+        - event: LogSetOwner(indexed address)
+          handler: handleLogSetOwner
+        - event: FundShutDown()
+          handler: handleFundShutDown
+
+  - name: AccountingDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: AccountingContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Accounting.ts
+      entities:
+        - Accounting
+      abis:
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+      eventHandlers:
+        - event: AssetAddition(indexed address)
+          handler: handleAssetAddition
+        - event: AssetRemoval(indexed address)
+          handler: handleAssetRemoval
+
+  - name: FeeManagerDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: FeeManagerContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/FeeManager.ts
+      entities:
+        - FeeManager
+        - ManagementFee
+        - PerformanceFee
+        - Fund
+        - Investment
+        - Investor
+      abis:
+        - name: FeeManagerContract
+          file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
+        - name: ManagementFeeContract
+          file: ./node_modules/@melonproject/protocol/out/ManagementFee.abi.json
+        - name: PerformanceFeeContract
+          file: ./node_modules/@melonproject/protocol/out/PerformanceFee.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+      eventHandlers:
+        - event: FeeRegistration(address)
+          handler: handleFeeRegistration
+        - event: FeeReward(uint256)
+          handler: handleFeeReward
+
+  - name: ParticipationDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: ParticipationContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Participation.ts
+      entities:
+        - Asset
+        - Participation
+        - Investor
+        - Investment
+        - InvestmentRequest
+        - Fund
+        - InvestorCount
+        - State
+        - InvestmentHistory
+        - FundHoldingsHistory
+      abis:
+        - name: ParticipationContract
+          file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+      eventHandlers:
+        - event: InvestmentRequest(indexed address,indexed address,uint256,uint256)
+          handler: handleInvestmentRequest
+        - event: RequestExecution(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleRequestExecution
+        - event: CancelRequest(indexed address)
+          handler: handleCancelRequest
+        - event: Redemption(indexed address,address[],uint256[],uint256)
+          handler: handleRedemption
+        - event: EnableInvestment(address[])
+          handler: handleEnableInvestment
+        - event: DisableInvestment(address[])
+          handler: handleDisableInvestment
+
+  - name: PolicyManagerDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: PolicyManagerContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/PolicyManager.ts
+      entities:
+        - PolicyManager
+        - Policy
+      abis:
+        - name: PolicyManagerContract
+          file: ./node_modules/@melonproject/protocol/out/PolicyManager.abi.json
+        - name: PolicyContract
+          file: ./node_modules/@melonproject/protocol/out/Policy.abi.json
+        - name: AssetBlackListContract
+          file: ./node_modules/@melonproject/protocol/out/AssetBlackList.abi.json
+        - name: AssetWhiteListContract
+          file: ./node_modules/@melonproject/protocol/out/AssetWhiteList.abi.json
+        - name: MaxConcentrationContract
+          file: ./node_modules/@melonproject/protocol/out/MaxConcentration.abi.json
+        - name: MaxPositionsContract
+          file: ./node_modules/@melonproject/protocol/out/MaxPositions.abi.json
+        - name: PriceToleranceContract
+          file: ./node_modules/@melonproject/protocol/out/PriceTolerance.abi.json
+      eventHandlers:
+        - event: Registration(indexed bytes4,uint8,indexed address)
+          handler: handleRegistration
+
+  - name: SharesDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: SharesContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Shares.ts
+      entities:
+        - Shares
+      abis:
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: Approval(indexed address,indexed address,uint256)
+          handler: handleApproval
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+
+  # current trading contract
+  - name: TradingDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: TradingContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Trading.ts
+      entities:
+        - Trading
+      abis:
+        - name: TradingContract
+          file: ./node_modules/@melonproject/protocol/out/Trading.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: ExchangeMethodCall(indexed address,indexed string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
+          handler: handleExchangeMethodCall
+
+  # old trading contract
+  - name: TradingDataSourceV101
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: TradingContractV101
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/TradingV101.ts
+      entities:
+        - Trading
+      abis:
+        - name: TradingContractV101
+          file: ./node_modules/@melonproject/protocol-v.1.0.1/out/Trading.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: ExchangeMethodCall(indexed address,indexed string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
+          handler: handleExchangeMethodCall
+
+  - name: VaultDataSource
+    kind: ethereum/contract
+    network: "{{meta.network}}"
+    source:
+      abi: VaultContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Vault.ts
+      entities:
+        - Vault
+      abis:
+        - name: VaultContract
+          file: ./node_modules/@melonproject/protocol/out/Vault.abi.json

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -310,8 +310,12 @@ templates:
         - Asset
         - AssetPriceUpdate
         - Fund
+        - FundHoldingsHistory
         - FundCalculationsHistory
-        - NetworkValue
+        - AssetPriceUpdate
+        - AssetPriceHistory
+        - MelonNetworkAssetHistory
+        - MelonNetworkHistory
         - Investment
         - InvestmentValuationHistory
         - Investor

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,12 +1,13 @@
-specVersion: 0.0.1
+specVersion: 0.0.2
 description: Melon protocol
 repository: https://github.com/melonproject/melon-subgraph
 schema:
   file: ./schema.graphql
+
 dataSources:
   - name: RegistryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       address: "0x1Bfd21f7db126a5966d2C09492676807a68859Ba"
       abi: RegistryContract
@@ -30,8 +31,7 @@ dataSources:
       eventHandlers:
         - event: VersionRegistration(indexed address)
           handler: handleVersionRegistration
-        - event: AssetUpsert(indexed
-            address,string,string,uint256,string,uint256,uint256[],bytes4[])
+        - event: AssetUpsert(indexed address,string,string,uint256,string,uint256,uint256[],bytes4[])
           handler: handleAssetUpsert
         - event: AssetRemoval(indexed address)
           handler: handleAssetRemoval
@@ -51,9 +51,10 @@ dataSources:
           handler: handleMGMChange
         - event: LogSetOwner(indexed address)
           handler: handleLogSetOwner
+
   - name: EngineDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       address: "0x7CaEc96607c5c7190d63B5A650E7CE34472352f5"
       abi: EngineContract
@@ -81,9 +82,10 @@ dataSources:
           handler: handleThaw
         - event: Burn(uint256)
           handler: handleBurn
+
   - name: PriceSourceDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       address: "0x4559DDD9E0a567bD8AB071ac106C1bC2d0C0b6Ef"
       abi: PriceSourceContract
@@ -123,9 +125,11 @@ dataSources:
       eventHandlers:
         - event: PriceUpdate(address[],uint256[])
           handler: handlePriceUpdate
+
+  # current version contract
   - name: VersionDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       address: "0x01Bde0b02740D6311e4a87CA112DeEEddb057EFB"
       abi: VersionContract
@@ -151,32 +155,11 @@ dataSources:
       eventHandlers:
         - event: NewFund(indexed address,indexed address,address[12])
           handler: handleNewFund
-    templates:
-      - name: HubDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: HubContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Hub.ts
-          entities:
-            - Fund
-            - FundCount
-            - State
-          abis:
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-          eventHandlers:
-            - event: LogSetOwner(indexed address)
-              handler: handleLogSetOwner
-            - event: FundShutDown()
-              handler: handleFundShutDown
+
+  # old Version Contract (first deployment)
   - name: VersionDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       address: "0xCB6c6Bdf0AA4cF0188518783b871931EFB64248f"
       abi: VersionContract
@@ -202,30 +185,10 @@ dataSources:
       eventHandlers:
         - event: NewFund(indexed address,indexed address,address[12])
           handler: handleNewFund
-    templates:
-      - name: HubDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: HubContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Hub.ts
-          entities:
-            - Fund
-            - FundCount
-            - State
-          abis:
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-          eventHandlers:
-            - event: FundShutDown()
-              handler: handleFundShutDown
+
   - name: AccountingFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: AccountingFactoryContract
       address: "0xeA41FD17121AAC5c79717C8528ce66a8e143e0c8"
@@ -245,30 +208,10 @@ dataSources:
           handler: handleNewInstance
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance1
-    templates:
-      - name: AccountingDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: AccountingContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Accounting.ts
-          entities:
-            - Accounting
-          abis:
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-          eventHandlers:
-            - event: AssetAddition(indexed address)
-              handler: handleAssetAddition
-            - event: AssetRemoval(indexed address)
-              handler: handleAssetRemoval
+
   - name: FeeManagerFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: FeeManagerFactoryContract
       address: "0xCB9CC04622ebb6D751E3516503Bc5418d980Ef13"
@@ -285,41 +228,10 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: FeeManagerDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: FeeManagerContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/FeeManager.ts
-          entities:
-            - FeeManager
-            - ManagementFee
-            - PerformanceFee
-            - Fund
-            - Investment
-            - Investor
-          abis:
-            - name: FeeManagerContract
-              file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
-            - name: ManagementFeeContract
-              file: ./node_modules/@melonproject/protocol/out/ManagementFee.abi.json
-            - name: PerformanceFeeContract
-              file: ./node_modules/@melonproject/protocol/out/PerformanceFee.abi.json
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-          eventHandlers:
-            - event: FeeRegistration(address)
-              handler: handleFeeRegistration
-            - event: FeeReward(uint256)
-              handler: handleFeeReward
+
   - name: ParticipationFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: ParticipationFactoryContract
       address: "0xA48227baEa91825c23b2A38B0A90CE2e2ae59987"
@@ -337,56 +249,10 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address,address[],address)
           handler: handleNewInstance
-    templates:
-      - name: ParticipationDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: ParticipationContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Participation.ts
-          entities:
-            - Asset
-            - Participation
-            - Investor
-            - Investment
-            - InvestmentRequest
-            - Fund
-            - InvestorCount
-            - State
-            - InvestmentHistory
-            - FundHoldingsHistory
-          abis:
-            - name: ParticipationContract
-              file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-            - name: HubContract
-              file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-            - name: PriceSourceContract
-              file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-          eventHandlers:
-            - event: InvestmentRequest(indexed address,indexed address,uint256,uint256)
-              handler: handleInvestmentRequest
-            - event: RequestExecution(indexed address,indexed address,indexed
-                address,uint256,uint256)
-              handler: handleRequestExecution
-            - event: CancelRequest(indexed address)
-              handler: handleCancelRequest
-            - event: Redemption(indexed address,address[],uint256[],uint256)
-              handler: handleRedemption
-            - event: EnableInvestment(address[])
-              handler: handleEnableInvestment
-            - event: DisableInvestment(address[])
-              handler: handleDisableInvestment
+
   - name: PolicyManagerFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: PolicyManagerFactoryContract
       address: "0xe06835e09Dd3eB24433252a77Ef573E022FcfB0b"
@@ -403,41 +269,10 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: PolicyManagerDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: PolicyManagerContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/PolicyManager.ts
-          entities:
-            - PolicyManager
-            - Policy
-          abis:
-            - name: PolicyManagerContract
-              file: ./node_modules/@melonproject/protocol/out/PolicyManager.abi.json
-            - name: PolicyContract
-              file: ./node_modules/@melonproject/protocol/out/Policy.abi.json
-            - name: AssetBlackListContract
-              file: ./node_modules/@melonproject/protocol/out/AssetBlackList.abi.json
-            - name: AssetWhiteListContract
-              file: ./node_modules/@melonproject/protocol/out/AssetWhiteList.abi.json
-            - name: MaxConcentrationContract
-              file: ./node_modules/@melonproject/protocol/out/MaxConcentration.abi.json
-            - name: MaxPositionsContract
-              file: ./node_modules/@melonproject/protocol/out/MaxPositions.abi.json
-            - name: PriceToleranceContract
-              file: ./node_modules/@melonproject/protocol/out/PriceTolerance.abi.json
-          eventHandlers:
-            - event: Registration(indexed bytes4,uint8,indexed address)
-              handler: handleRegistration
+
   - name: SharesFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: SharesFactoryContract
       address: "0xC563Fb444441fd73431384006e7A81955c0d4F89"
@@ -454,30 +289,11 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: SharesDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: SharesContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Shares.ts
-          entities:
-            - Shares
-          abis:
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-          eventHandlers:
-            - event: Approval(indexed address,indexed address,uint256)
-              handler: handleApproval
-            - event: Transfer(indexed address,indexed address,uint256)
-              handler: handleTransfer
+
+  # current trading factory
   - name: TradingFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: TradingFactoryContract
       address: "0x6E57E54Ba53495066F400c026ecA1ef7FCa9Cb44"
@@ -494,35 +310,11 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address,address[],address[],address)
           handler: handleNewInstance
-    templates:
-      - name: TradingDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: TradingContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Trading.ts
-          entities:
-            - Trading
-          abis:
-            - name: TradingContract
-              file: ./node_modules/@melonproject/protocol/out/Trading.abi.json
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-            - name: PriceSourceContract
-              file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-          eventHandlers:
-            - event: ExchangeMethodCall(indexed address,indexed
-                string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
-              handler: handleExchangeMethodCall
+
+    # old trading factory
   - name: TradingFactoryDataSourceV101
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: TradingFactoryContractV101
       address: "0xe2c3fe25336eE3bD71dcA3380b7423a3bDef3d8C"
@@ -539,35 +331,10 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address,address[],address[],bool[],address)
           handler: handleNewInstance
-    templates:
-      - name: TradingDataSourceV101
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: TradingContractV101
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/TradingV101.ts
-          entities:
-            - Trading
-          abis:
-            - name: TradingContractV101
-              file: ./node_modules/@melonproject/protocol-v.1.0.1/out/Trading.abi.json
-            - name: AccountingContract
-              file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-            - name: PriceSourceContract
-              file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-            - name: SharesContract
-              file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-          eventHandlers:
-            - event: ExchangeMethodCall(indexed address,indexed
-                string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
-              handler: handleExchangeMethodCall
+
   - name: VaultFactoryDataSource
     kind: ethereum/contract
-    network: mainnet
+    network: "mainnet"
     source:
       abi: VaultFactoryContract
       address: "0x42822b1f64249154Fc82f7F6246AE7C69254F30A"
@@ -584,19 +351,251 @@ dataSources:
       eventHandlers:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
-    templates:
-      - name: VaultDataSource
-        kind: ethereum/contract
-        network: mainnet
-        source:
-          abi: VaultContract
-        mapping:
-          kind: ethereum/events
-          apiVersion: 0.0.3
-          language: wasm/assemblyscript
-          file: ./src/mappings/Vault.ts
-          entities:
-            - Vault
-          abis:
-            - name: VaultContract
-              file: ./node_modules/@melonproject/protocol/out/Vault.abi.json
+
+#
+# TEMPLATES
+#
+#
+templates:
+  - name: HubDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: HubContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Hub.ts
+      entities:
+        - Fund
+        - FundCount
+        - State
+      abis:
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+      eventHandlers:
+        - event: LogSetOwner(indexed address)
+          handler: handleLogSetOwner
+        - event: FundShutDown()
+          handler: handleFundShutDown
+
+  - name: AccountingDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: AccountingContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Accounting.ts
+      entities:
+        - Accounting
+      abis:
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+      eventHandlers:
+        - event: AssetAddition(indexed address)
+          handler: handleAssetAddition
+        - event: AssetRemoval(indexed address)
+          handler: handleAssetRemoval
+
+  - name: FeeManagerDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: FeeManagerContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/FeeManager.ts
+      entities:
+        - FeeManager
+        - ManagementFee
+        - PerformanceFee
+        - Fund
+        - Investment
+        - Investor
+      abis:
+        - name: FeeManagerContract
+          file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
+        - name: ManagementFeeContract
+          file: ./node_modules/@melonproject/protocol/out/ManagementFee.abi.json
+        - name: PerformanceFeeContract
+          file: ./node_modules/@melonproject/protocol/out/PerformanceFee.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+      eventHandlers:
+        - event: FeeRegistration(address)
+          handler: handleFeeRegistration
+        - event: FeeReward(uint256)
+          handler: handleFeeReward
+
+  - name: ParticipationDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: ParticipationContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Participation.ts
+      entities:
+        - Asset
+        - Participation
+        - Investor
+        - Investment
+        - InvestmentRequest
+        - Fund
+        - InvestorCount
+        - State
+        - InvestmentHistory
+        - FundHoldingsHistory
+      abis:
+        - name: ParticipationContract
+          file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+      eventHandlers:
+        - event: InvestmentRequest(indexed address,indexed address,uint256,uint256)
+          handler: handleInvestmentRequest
+        - event: RequestExecution(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleRequestExecution
+        - event: CancelRequest(indexed address)
+          handler: handleCancelRequest
+        - event: Redemption(indexed address,address[],uint256[],uint256)
+          handler: handleRedemption
+        - event: EnableInvestment(address[])
+          handler: handleEnableInvestment
+        - event: DisableInvestment(address[])
+          handler: handleDisableInvestment
+
+  - name: PolicyManagerDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: PolicyManagerContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/PolicyManager.ts
+      entities:
+        - PolicyManager
+        - Policy
+      abis:
+        - name: PolicyManagerContract
+          file: ./node_modules/@melonproject/protocol/out/PolicyManager.abi.json
+        - name: PolicyContract
+          file: ./node_modules/@melonproject/protocol/out/Policy.abi.json
+        - name: AssetBlackListContract
+          file: ./node_modules/@melonproject/protocol/out/AssetBlackList.abi.json
+        - name: AssetWhiteListContract
+          file: ./node_modules/@melonproject/protocol/out/AssetWhiteList.abi.json
+        - name: MaxConcentrationContract
+          file: ./node_modules/@melonproject/protocol/out/MaxConcentration.abi.json
+        - name: MaxPositionsContract
+          file: ./node_modules/@melonproject/protocol/out/MaxPositions.abi.json
+        - name: PriceToleranceContract
+          file: ./node_modules/@melonproject/protocol/out/PriceTolerance.abi.json
+      eventHandlers:
+        - event: Registration(indexed bytes4,uint8,indexed address)
+          handler: handleRegistration
+
+  - name: SharesDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: SharesContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Shares.ts
+      entities:
+        - Shares
+      abis:
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: Approval(indexed address,indexed address,uint256)
+          handler: handleApproval
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+
+  # current trading contract
+  - name: TradingDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: TradingContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Trading.ts
+      entities:
+        - Trading
+      abis:
+        - name: TradingContract
+          file: ./node_modules/@melonproject/protocol/out/Trading.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: ExchangeMethodCall(indexed address,indexed string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
+          handler: handleExchangeMethodCall
+
+  # old trading contract
+  - name: TradingDataSourceV101
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: TradingContractV101
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/TradingV101.ts
+      entities:
+        - Trading
+      abis:
+        - name: TradingContractV101
+          file: ./node_modules/@melonproject/protocol-v.1.0.1/out/Trading.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: ExchangeMethodCall(indexed address,indexed string,address[6],uint256[8],bytes32,bytes,bytes,bytes)
+          handler: handleExchangeMethodCall
+
+  - name: VaultDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: VaultContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Vault.ts
+      entities:
+        - Vault
+      abis:
+        - name: VaultContract
+          file: ./node_modules/@melonproject/protocol/out/Vault.abi.json

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -15,9 +15,9 @@ dataSources:
   #
   - name: RegistryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
-      address: "0x1Bfd21f7db126a5966d2C09492676807a68859Ba"
+      address: "0x5A54505376d9D2038E913700959aECF8ec48a840"
       abi: RegistryContract
     mapping:
       kind: ethereum/events
@@ -65,10 +65,10 @@ dataSources:
   #
   - name: AccountingFactoryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: AccountingFactoryContract
-      address: "0xeA41FD17121AAC5c79717C8528ce66a8e143e0c8"
+      address: "0x0C87A4Af069aDbD684d052A85f4979839D9aD8C2"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -88,10 +88,10 @@ dataSources:
 
   - name: FeeManagerFactoryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: FeeManagerFactoryContract
-      address: "0xCB9CC04622ebb6D751E3516503Bc5418d980Ef13"
+      address: "0x373f70D1BE036A6fF2CBF7BCB613E5c08A7a663d"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -108,10 +108,10 @@ dataSources:
 
   - name: ParticipationFactoryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: ParticipationFactoryContract
-      address: "0xA48227baEa91825c23b2A38B0A90CE2e2ae59987"
+      address: "0x5aF8112855df2150869C39C18Ef80ee8aeD2F384"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -129,10 +129,10 @@ dataSources:
 
   - name: PolicyManagerFactoryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: PolicyManagerFactoryContract
-      address: "0xe06835e09Dd3eB24433252a77Ef573E022FcfB0b"
+      address: "0x7B83e06040fA258199966A886738cc2eDDF08cA4"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -149,10 +149,10 @@ dataSources:
 
   - name: SharesFactoryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: SharesFactoryContract
-      address: "0xC563Fb444441fd73431384006e7A81955c0d4F89"
+      address: "0x11F96277d5556DCe22c838Bb61Cf2c25311ec7e3"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -169,10 +169,10 @@ dataSources:
 
   - name: TradingFactoryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: TradingFactoryContract
-      address: "0x6E57E54Ba53495066F400c026ecA1ef7FCa9Cb44"
+      address: "0xB441268a8826836C76820CDF403aAd5bFB4AB628"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -190,7 +190,7 @@ dataSources:
     # old trading factory
   - name: TradingFactoryDataSourceV101
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: TradingFactoryContractV101
       address: "0xe2c3fe25336eE3bD71dcA3380b7423a3bDef3d8C"
@@ -210,10 +210,10 @@ dataSources:
 
   - name: VaultFactoryDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: VaultFactoryContract
-      address: "0x42822b1f64249154Fc82f7F6246AE7C69254F30A"
+      address: "0xf2cDAdC747Ae8d6b60191D625f76C23fC1230259"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -239,7 +239,7 @@ templates:
   #
   - name: VersionDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: VersionContract
     mapping:
@@ -267,7 +267,7 @@ templates:
 
   - name: EngineDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: EngineContract
     mapping:
@@ -297,7 +297,7 @@ templates:
 
   - name: PriceSourceDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: PriceSourceContract
     mapping:
@@ -342,7 +342,7 @@ templates:
   #
   - name: HubDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: HubContract
     mapping:
@@ -358,14 +358,12 @@ templates:
         - name: HubContract
           file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
       eventHandlers:
-        - event: LogSetOwner(indexed address)
-          handler: handleLogSetOwner
         - event: FundShutDown()
           handler: handleFundShutDown
 
   - name: AccountingDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: AccountingContract
     mapping:
@@ -386,7 +384,7 @@ templates:
 
   - name: FeeManagerDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: FeeManagerContract
     mapping:
@@ -418,7 +416,7 @@ templates:
 
   - name: ParticipationDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: ParticipationContract
     mapping:
@@ -464,7 +462,7 @@ templates:
 
   - name: PolicyManagerDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: PolicyManagerContract
     mapping:
@@ -496,7 +494,7 @@ templates:
 
   - name: SharesDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: SharesContract
     mapping:
@@ -518,7 +516,7 @@ templates:
   # current trading contract
   - name: TradingDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: TradingContract
     mapping:
@@ -544,7 +542,7 @@ templates:
   # old trading contract
   - name: TradingDataSourceV101
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: TradingContractV101
     mapping:
@@ -569,7 +567,7 @@ templates:
 
   - name: VaultDataSource
     kind: ethereum/contract
-    network: "mainnet"
+    network: "kovan"
     source:
       abi: VaultContract
     mapping:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -310,8 +310,12 @@ templates:
         - Asset
         - AssetPriceUpdate
         - Fund
+        - FundHoldingsHistory
         - FundCalculationsHistory
-        - NetworkValue
+        - AssetPriceUpdate
+        - AssetPriceHistory
+        - MelonNetworkAssetHistory
+        - MelonNetworkHistory
         - Investment
         - InvestmentValuationHistory
         - Investor

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -15,9 +15,9 @@ dataSources:
   #
   - name: RegistryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
-      address: "0x5A54505376d9D2038E913700959aECF8ec48a840"
+      address: "0x1Bfd21f7db126a5966d2C09492676807a68859Ba"
       abi: RegistryContract
     mapping:
       kind: ethereum/events
@@ -65,10 +65,10 @@ dataSources:
   #
   - name: AccountingFactoryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: AccountingFactoryContract
-      address: "0x0C87A4Af069aDbD684d052A85f4979839D9aD8C2"
+      address: "0xeA41FD17121AAC5c79717C8528ce66a8e143e0c8"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -88,10 +88,10 @@ dataSources:
 
   - name: FeeManagerFactoryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: FeeManagerFactoryContract
-      address: "0x373f70D1BE036A6fF2CBF7BCB613E5c08A7a663d"
+      address: "0xCB9CC04622ebb6D751E3516503Bc5418d980Ef13"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -108,10 +108,10 @@ dataSources:
 
   - name: ParticipationFactoryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: ParticipationFactoryContract
-      address: "0x5aF8112855df2150869C39C18Ef80ee8aeD2F384"
+      address: "0xA48227baEa91825c23b2A38B0A90CE2e2ae59987"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -129,10 +129,10 @@ dataSources:
 
   - name: PolicyManagerFactoryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: PolicyManagerFactoryContract
-      address: "0x7B83e06040fA258199966A886738cc2eDDF08cA4"
+      address: "0xe06835e09Dd3eB24433252a77Ef573E022FcfB0b"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -149,10 +149,10 @@ dataSources:
 
   - name: SharesFactoryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: SharesFactoryContract
-      address: "0x11F96277d5556DCe22c838Bb61Cf2c25311ec7e3"
+      address: "0xC563Fb444441fd73431384006e7A81955c0d4F89"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -169,10 +169,10 @@ dataSources:
 
   - name: TradingFactoryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: TradingFactoryContract
-      address: "0xB441268a8826836C76820CDF403aAd5bFB4AB628"
+      address: "0x6E57E54Ba53495066F400c026ecA1ef7FCa9Cb44"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -190,7 +190,7 @@ dataSources:
     # old trading factory
   - name: TradingFactoryDataSourceV101
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: TradingFactoryContractV101
       address: "0xe2c3fe25336eE3bD71dcA3380b7423a3bDef3d8C"
@@ -210,10 +210,10 @@ dataSources:
 
   - name: VaultFactoryDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: VaultFactoryContract
-      address: "0xf2cDAdC747Ae8d6b60191D625f76C23fC1230259"
+      address: "0x42822b1f64249154Fc82f7F6246AE7C69254F30A"
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.3
@@ -239,7 +239,7 @@ templates:
   #
   - name: VersionDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: VersionContract
     mapping:
@@ -267,7 +267,7 @@ templates:
 
   - name: EngineDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: EngineContract
     mapping:
@@ -297,7 +297,7 @@ templates:
 
   - name: PriceSourceDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: PriceSourceContract
     mapping:
@@ -342,7 +342,7 @@ templates:
   #
   - name: HubDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: HubContract
     mapping:
@@ -363,7 +363,7 @@ templates:
 
   - name: AccountingDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: AccountingContract
     mapping:
@@ -384,7 +384,7 @@ templates:
 
   - name: FeeManagerDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: FeeManagerContract
     mapping:
@@ -416,7 +416,7 @@ templates:
 
   - name: ParticipationDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: ParticipationContract
     mapping:
@@ -462,7 +462,7 @@ templates:
 
   - name: PolicyManagerDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: PolicyManagerContract
     mapping:
@@ -494,7 +494,7 @@ templates:
 
   - name: SharesDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: SharesContract
     mapping:
@@ -516,7 +516,7 @@ templates:
   # current trading contract
   - name: TradingDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: TradingContract
     mapping:
@@ -542,7 +542,7 @@ templates:
   # old trading contract
   - name: TradingDataSourceV101
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: TradingContractV101
     mapping:
@@ -567,7 +567,7 @@ templates:
 
   - name: VaultDataSource
     kind: ethereum/contract
-    network: "kovan"
+    network: "mainnet"
     source:
       abi: VaultContract
     mapping:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -4,7 +4,15 @@ repository: https://github.com/melonproject/melon-subgraph
 schema:
   file: ./schema.graphql
 
+###############################################################################
+#
+# Contracts with fixed addresses
+#
+###############################################################################
 dataSources:
+  #
+  # Registry contract as main entry point
+  #
   - name: RegistryDataSource
     kind: ethereum/contract
     network: "mainnet"
@@ -52,140 +60,9 @@ dataSources:
         - event: LogSetOwner(indexed address)
           handler: handleLogSetOwner
 
-  - name: EngineDataSource
-    kind: ethereum/contract
-    network: "mainnet"
-    source:
-      address: "0x7CaEc96607c5c7190d63B5A650E7CE34472352f5"
-      abi: EngineContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/Engine.ts
-      entities:
-        - Engine
-        - Registry
-      abis:
-        - name: EngineContract
-          file: ./node_modules/@melonproject/protocol/out/Engine.abi.json
-        - name: MlnContract
-          file: ./node_modules/@melonproject/protocol/out/PreminedToken.abi.json
-      eventHandlers:
-        - event: SetAmguPrice(uint256)
-          handler: handleSetAmguPrice
-        - event: RegistryChange(address)
-          handler: handleRegistryChange
-        - event: AmguPaid(uint256)
-          handler: handleAmguPaid
-        - event: Thaw(uint256)
-          handler: handleThaw
-        - event: Burn(uint256)
-          handler: handleBurn
-
-  - name: PriceSourceDataSource
-    kind: ethereum/contract
-    network: "mainnet"
-    source:
-      address: "0x4559DDD9E0a567bD8AB071ac106C1bC2d0C0b6Ef"
-      abi: PriceSourceContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/PriceSource.ts
-      entities:
-        - State
-        - Asset
-        - AssetPriceUpdate
-        - Fund
-        - FundCalculationsHistory
-        - NetworkValue
-        - Investment
-        - InvestmentValuationHistory
-        - Investor
-        - InvestorValuationHistory
-      abis:
-        - name: PriceSourceContract
-          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
-        - name: RegistryContract
-          file: ./node_modules/@melonproject/protocol/out/Registry.abi.json
-        - name: VersionContract
-          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
-        - name: HubContract
-          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-        - name: AccountingContract
-          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-        - name: SharesContract
-          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-        - name: ParticipationContract
-          file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
-        - name: FeeManagerContract
-          file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
-      eventHandlers:
-        - event: PriceUpdate(address[],uint256[])
-          handler: handlePriceUpdate
-
-  # current version contract
-  - name: VersionDataSource
-    kind: ethereum/contract
-    network: "mainnet"
-    source:
-      address: "0x01Bde0b02740D6311e4a87CA112DeEEddb057EFB"
-      abi: VersionContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/Version.ts
-      entities:
-        - Fund
-        - FundCount
-        - State
-        - FundCalculationsHistory
-      abis:
-        - name: VersionContract
-          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
-        - name: HubContract
-          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-        - name: AccountingContract
-          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-        - name: SharesContract
-          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-      eventHandlers:
-        - event: NewFund(indexed address,indexed address,address[12])
-          handler: handleNewFund
-
-  # old Version Contract (first deployment)
-  - name: VersionDataSource
-    kind: ethereum/contract
-    network: "mainnet"
-    source:
-      address: "0xCB6c6Bdf0AA4cF0188518783b871931EFB64248f"
-      abi: VersionContract
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.3
-      language: wasm/assemblyscript
-      file: ./src/mappings/Version.ts
-      entities:
-        - Fund
-        - FundCount
-        - State
-        - FundCalculationsHistory
-      abis:
-        - name: VersionContract
-          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
-        - name: HubContract
-          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
-        - name: AccountingContract
-          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
-        - name: SharesContract
-          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
-      eventHandlers:
-        - event: NewFund(indexed address,indexed address,address[12])
-          handler: handleNewFund
-
+  #
+  # Factory contracts for fund spokes
+  #
   - name: AccountingFactoryDataSource
     kind: ethereum/contract
     network: "mainnet"
@@ -290,7 +167,6 @@ dataSources:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
 
-  # current trading factory
   - name: TradingFactoryDataSource
     kind: ethereum/contract
     network: "mainnet"
@@ -352,11 +228,118 @@ dataSources:
         - event: NewInstance(indexed address,indexed address)
           handler: handleNewInstance
 
+###############################################################################
 #
-# TEMPLATES
+# Contracts with dynamically set addresses
 #
-#
+###############################################################################
 templates:
+  #
+  # Infrastructure templates
+  #
+  - name: VersionDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: VersionContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Version.ts
+      entities:
+        - Fund
+        - FundCount
+        - State
+        - FundCalculationsHistory
+      abis:
+        - name: VersionContract
+          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+      eventHandlers:
+        - event: NewFund(indexed address,indexed address,address[12])
+          handler: handleNewFund
+
+  - name: EngineDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: EngineContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/Engine.ts
+      entities:
+        - Engine
+        - Registry
+      abis:
+        - name: EngineContract
+          file: ./node_modules/@melonproject/protocol/out/Engine.abi.json
+        - name: MlnContract
+          file: ./node_modules/@melonproject/protocol/out/PreminedToken.abi.json
+      eventHandlers:
+        - event: SetAmguPrice(uint256)
+          handler: handleSetAmguPrice
+        - event: RegistryChange(address)
+          handler: handleRegistryChange
+        - event: AmguPaid(uint256)
+          handler: handleAmguPaid
+        - event: Thaw(uint256)
+          handler: handleThaw
+        - event: Burn(uint256)
+          handler: handleBurn
+
+  - name: PriceSourceDataSource
+    kind: ethereum/contract
+    network: "mainnet"
+    source:
+      abi: PriceSourceContract
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/PriceSource.ts
+      entities:
+        - State
+        - Asset
+        - AssetPriceUpdate
+        - Fund
+        - FundCalculationsHistory
+        - NetworkValue
+        - Investment
+        - InvestmentValuationHistory
+        - Investor
+        - InvestorValuationHistory
+      abis:
+        - name: PriceSourceContract
+          file: ./node_modules/@melonproject/protocol/out/KyberPriceFeed.abi.json
+        - name: RegistryContract
+          file: ./node_modules/@melonproject/protocol/out/Registry.abi.json
+        - name: VersionContract
+          file: ./node_modules/@melonproject/protocol/out/Version.abi.json
+        - name: HubContract
+          file: ./node_modules/@melonproject/protocol/out/Hub.abi.json
+        - name: AccountingContract
+          file: ./node_modules/@melonproject/protocol/out/Accounting.abi.json
+        - name: SharesContract
+          file: ./node_modules/@melonproject/protocol/out/Shares.abi.json
+        - name: ParticipationContract
+          file: ./node_modules/@melonproject/protocol/out/Participation.abi.json
+        - name: FeeManagerContract
+          file: ./node_modules/@melonproject/protocol/out/FeeManager.abi.json
+      eventHandlers:
+        - event: PriceUpdate(address[],uint256[])
+          handler: handlePriceUpdate
+
+  #
+  # Fund hub/spokes templates
+  #
   - name: HubDataSource
     kind: ethereum/contract
     network: "mainnet"

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,10 +423,10 @@
   optionalDependencies:
     keytar "^4.6.0"
 
-"@graphprotocol/graph-ts@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.15.0.tgz#6a2429f31ec7ac5f582101a75a0e780c6b95c462"
-  integrity sha512-rYrIUDNGdQTxU+UogI5OhjP73LL8B9jwB29jysztaaSRqJumf8DEmftG0K42+7CvWtYfpiZNKpGpKt/xUR80NQ==
+"@graphprotocol/graph-ts@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.15.1.tgz#d6cc85197e45dda9bb4083654c183470ff23333e"
+  integrity sha512-l5veH44ULpKq1kLudbfJctgxLaLpnLnYiDIIZn+N8UC1SrpqjLhJyRMfm+uH4xTglmAwI74wyynKWktXp44/iw==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
 
@@ -866,9 +866,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
+"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
-  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"
@@ -3912,6 +3912,14 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
+  dependencies:
+    min-document "^2.19.0"
+    process "^0.11.10"
+
 global@~4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
@@ -6473,6 +6481,11 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 process@~0.5.1:
   version "0.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,22 +398,22 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@graphprotocol/graph-cli@^0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.13.1.tgz#8f810a11ec7c1b093ff5eab2c49b647927c2fb28"
-  integrity sha512-POm7ZDdTcYOmDbIOs8AdMy/1Ypdst+4L+2gdQ1ki6SzgKJV01X5soVhJhNP+ivlIwVEgRxQxGhbv3Jj7vFwO1A==
+"@graphprotocol/graph-cli@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.15.0.tgz#85bad509a55e212c2dc8f3e5113cdfc6323224d8"
+  integrity sha512-7wfHRDDxKbOrcp9c71dxqDIYviKPyDvApD1oC51fOWLsm6aFe9mFmZDfF3jp+hIeYvSX6dBwakNAphsX9cc1jA==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
     chalk "^2.4.1"
-    chokidar "^2.0.4"
-    debug "^3.1.0"
-    fs-extra "^7.0.1"
+    chokidar "^3.0.2"
+    debug "^4.1.1"
+    fs-extra "^8.1.0"
     glob "^7.1.2"
     gluegun "^3.0.0"
     graphql "^14.0.2"
     immutable "^3.8.2"
-    ipfs-http-client "^28.1.2"
-    jayson "^2.0.6"
+    ipfs-http-client "^34.0.0"
+    jayson "^3.0.2"
     js-yaml "^3.13.1"
     node-fetch "^2.3.0"
     pkginfo "^0.4.1"
@@ -423,10 +423,10 @@
   optionalDependencies:
     keytar "^4.6.0"
 
-"@graphprotocol/graph-ts@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.13.0.tgz#5c1c440094270209eb68647ce59f8cad0987dda3"
-  integrity sha512-ajrGdh+/wDgMg0+FYw+ZmbUAaveorD5IHaSWAtms0PFhoiebeBcYHCCFh0FYWNJtumG9Il3GNkD9zo48iEwWSA==
+"@graphprotocol/graph-ts@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.15.0.tgz#6a2429f31ec7ac5f582101a75a0e780c6b95c462"
+  integrity sha512-rYrIUDNGdQTxU+UogI5OhjP73LL8B9jwB29jysztaaSRqJumf8DEmftG0K42+7CvWtYfpiZNKpGpKt/xUR80NQ==
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
 
@@ -647,6 +647,13 @@ abbrev@1.0.x:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha1-kbR5JYinc4wl813W9jdSovh3YTU=
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 abortcontroller-polyfill@^1.1.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz#de69af32ae926c210b7efbcc29bf644ee4838b00"
@@ -763,6 +770,14 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+anymatch@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.0.tgz#e609350e50a9313b472789b2f14ef35808ee14d6"
+  integrity sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 apisauce@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-1.0.2.tgz#3605dbf4f19896618a0199f2cb717546b8971a06"
@@ -851,9 +866,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
+"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
-  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"
@@ -912,6 +927,13 @@ async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0, async@^2.6.1:
   integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
   dependencies:
     lodash "^4.17.11"
+
+async@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1511,11 +1533,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-big.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
 bignumber.js@7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
@@ -1525,6 +1542,11 @@ bignumber.js@^8.0.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
   integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
+
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
   version "2.0.7"
@@ -1539,6 +1561,11 @@ binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
+
+binary-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
+  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
 binaryen@77.0.0-nightly.20190407:
   version "77.0.0-nightly.20190407"
@@ -1621,13 +1648,12 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bl@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.0.tgz#e1a574cdf528e4053019bb800b041c0ac88da493"
-  integrity sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==
+bl@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-3.0.0.tgz#3611ec00579fd18561754360b21e9f784500ff88"
+  integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
   dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
+    readable-stream "^3.0.1"
 
 blakejs@^1.1.0:
   version "1.1.0"
@@ -1733,6 +1759,13 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+braces@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -1806,7 +1839,7 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
-bs58@4.0.1, bs58@=4.0.1, bs58@^4.0.0, bs58@^4.0.1:
+bs58@=4.0.1, bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
@@ -1883,6 +1916,14 @@ buffer@^5.0.5, buffer@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.2.tgz#2012872776206182480eccb2c0fba5f672a2efef"
+  integrity sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -2069,25 +2110,40 @@ chokidar@^2.0.4:
   optionalDependencies:
     fsevents "^1.2.7"
 
+chokidar@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.0.2.tgz#0d1cd6d04eb2df0327446188cd13736a3367d681"
+  integrity sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==
+  dependencies:
+    anymatch "^3.0.1"
+    braces "^3.0.2"
+    glob-parent "^5.0.0"
+    is-binary-path "^2.1.0"
+    is-glob "^4.0.1"
+    normalize-path "^3.0.0"
+    readdirp "^3.1.1"
+  optionalDependencies:
+    fsevents "^2.0.6"
+
 chownr@^1.0.1, chownr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
-cids@~0.5.4, cids@~0.5.5, cids@~0.5.6:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.8.tgz#3d5000c3856a2d3c00967b21265aa57142611aa0"
-  integrity sha512-Ye8TZP3YQfy0j+i5k+LPHdTY3JOvTwN1pxds44p6BRUv8PTMOAF/Vt4Bc+oiIQ0Sktn0iftkUHgqKNHIMwhshA==
-  dependencies:
-    class-is "^1.1.0"
-    multibase "~0.6.0"
-    multicodec "~0.5.0"
-    multihashes "~0.4.14"
-
 cids@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.0.tgz#c1f440ab5990df56b6db80e44a0075e0c281e3cd"
   integrity sha512-Vo0Pd/UZjtQ0R8JQHf57yaDMcsz58/+7nbaNXpN++l5o9VZiFdAOzkADV4siZuTGxfTjf/O11T6+nm+KTP26Pw==
+  dependencies:
+    class-is "^1.1.0"
+    multibase "~0.6.0"
+    multicodec "~0.5.1"
+    multihashes "~0.4.14"
+
+cids@~0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.1.tgz#d8bba49a35a0e82110879b5001abf1039c62347f"
+  integrity sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==
   dependencies:
     class-is "^1.1.0"
     multibase "~0.6.0"
@@ -2254,15 +2310,12 @@ concat-stream@^1.5.1:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-stream@^2.0.0:
+"concat-stream@github:hugomrdias/concat-stream#feat/smaller":
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
-  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  resolved "https://codeload.github.com/hugomrdias/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
   dependencies:
-    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.0.2"
-    typedarray "^0.0.6"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -2441,14 +2494,14 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0:
+debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -2814,6 +2867,11 @@ err-code@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
   integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
+
+err-code@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.0.tgz#452dadddde12356b1dd5a85f33b28ddda377ef2a"
+  integrity sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw==
 
 errno@~0.1.1:
   version "0.1.7"
@@ -3271,6 +3329,11 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter3@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.1.1.tgz#47786bdaa087caf7b1b75e73abc5c7d540158cd0"
@@ -3342,6 +3405,11 @@ expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
+explain-error@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/explain-error/-/explain-error-1.0.4.tgz#a793d3ac0cad4c6ab571e9968fbbab6cb2532929"
+  integrity sha1-p5PTrAytTGq1cemWj7urbLJTKSk=
 
 express@^4.14.0:
   version "4.16.4"
@@ -3510,6 +3578,13 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
@@ -3622,12 +3697,12 @@ fs-extra@^2.0.0, fs-extra@^2.1.2:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
-fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
-    graceful-fs "^4.1.2"
+    graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -3668,6 +3743,11 @@ fsevents@^1.2.7:
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
+
+fsevents@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.0.7.tgz#382c9b443c6cbac4c57187cdda23aa3bf1ccfc2a"
+  integrity sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==
 
 fstream@^1.0.2, fstream@^1.0.8:
   version "1.0.11"
@@ -3802,6 +3882,13 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-parent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
+  integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
@@ -3899,6 +3986,11 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graceful-fs@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -4058,6 +4150,11 @@ heap@0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
   integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
+
+hi-base32@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/hi-base32/-/hi-base32-0.5.0.tgz#61329f76a31f31008533f1c36f2473e259d64571"
+  integrity sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4236,7 +4333,7 @@ ipaddr.js@1.9.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
   integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
 
-ipfs-block@~0.8.0:
+ipfs-block@~0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/ipfs-block/-/ipfs-block-0.8.1.tgz#05e1068832775e8f1c2da5b64106cc837fd2acb9"
   integrity sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==
@@ -4244,88 +4341,107 @@ ipfs-block@~0.8.0:
     cids "~0.7.0"
     class-is "^1.1.0"
 
-ipfs-http-client@^28.1.2:
-  version "28.1.2"
-  resolved "https://registry.yarnpkg.com/ipfs-http-client/-/ipfs-http-client-28.1.2.tgz#7e03fc175039a2d841299366bf23d7141df8bc43"
-  integrity sha512-NThmLsBBRAboV8Sgs87U0QV4XUrIR58pdiGJ2v4VFHFmJEIPNQInFVw0x3btnElKnOd3FphE72+8918PcskVbQ==
+ipfs-http-client@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/ipfs-http-client/-/ipfs-http-client-34.0.0.tgz#8804d06a11c22306332a8ffa0949b6f672a0c9c8"
+  integrity sha512-4RCkk8ix4Dqn6sxqFVwuXWCZ1eLFPsVaj6Ijvu1fs9VYgxgVudsW9PWwarlr4mw1xUCmPWYyXnEbGgzBrfMy0Q==
   dependencies:
+    abort-controller "^3.0.0"
     async "^2.6.1"
-    big.js "^5.2.2"
-    bl "^2.1.2"
+    bignumber.js "^9.0.0"
+    bl "^3.0.0"
     bs58 "^4.0.1"
-    cids "~0.5.5"
-    concat-stream "^2.0.0"
+    buffer "^5.4.2"
+    cids "~0.7.1"
+    concat-stream "github:hugomrdias/concat-stream#feat/smaller"
     debug "^4.1.0"
     detect-node "^2.0.4"
     end-of-stream "^1.4.1"
-    err-code "^1.1.2"
+    err-code "^2.0.0"
+    explain-error "^1.0.4"
     flatmap "0.0.3"
     glob "^7.1.3"
-    ipfs-block "~0.8.0"
-    ipfs-unixfs "~0.1.16"
-    ipld-dag-cbor "~0.13.0"
-    ipld-dag-pb "~0.15.0"
-    is-ipfs "~0.4.7"
+    ipfs-block "~0.8.1"
+    ipfs-utils "~0.0.3"
+    ipld-dag-cbor "~0.15.0"
+    ipld-dag-pb "~0.17.3"
+    ipld-raw "^4.0.0"
+    is-ipfs "~0.6.1"
     is-pull-stream "0.0.0"
-    is-stream "^1.1.0"
-    libp2p-crypto "~0.16.0"
-    lodash "^4.17.11"
+    is-stream "^2.0.0"
+    iso-stream-http "~0.1.2"
+    iso-url "~0.4.6"
+    iterable-ndjson "^1.1.0"
+    just-kebab-case "^1.1.0"
+    just-map-keys "^1.1.0"
+    kind-of "^6.0.2"
+    ky "^0.11.2"
+    ky-universal "^0.2.2"
     lru-cache "^5.1.1"
-    multiaddr "^6.0.0"
+    multiaddr "^6.0.6"
     multibase "~0.6.0"
+    multicodec "~0.5.1"
     multihashes "~0.4.14"
-    ndjson "^1.5.0"
+    ndjson "github:hugomrdias/ndjson#feat/readable-stream3"
     once "^1.4.0"
-    peer-id "~0.12.1"
-    peer-info "~0.15.0"
+    peer-id "~0.12.3"
+    peer-info "~0.15.1"
+    promise-nodeify "^3.0.1"
     promisify-es6 "^1.0.3"
     pull-defer "~0.2.3"
-    pull-pushable "^2.2.0"
-    pull-stream-to-stream "^1.3.4"
+    pull-stream "^3.6.9"
+    pull-to-stream "~0.1.1"
     pump "^3.0.0"
     qs "^6.5.2"
-    readable-stream "^3.0.6"
-    stream-http "^3.0.0"
+    readable-stream "^3.1.1"
     stream-to-pull-stream "^1.7.2"
-    streamifier "~0.1.1"
-    tar-stream "^1.6.2"
-    through2 "^3.0.0"
+    tar-stream "^2.0.1"
+    through2 "^3.0.1"
 
-ipfs-unixfs@~0.1.16:
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-0.1.16.tgz#41140f4359f1b8fe7a970052663331091c5f54c4"
-  integrity sha512-TX9Dyu77MxpLzGh/LcQne95TofOyvOeW0oOi72aBMMcV1ItP3684e6NTG9KY1qzdrC+ZUR8kT7y18J058n8KXg==
+ipfs-utils@~0.0.3:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/ipfs-utils/-/ipfs-utils-0.0.4.tgz#946114cfeb6afb4454b4ccb10d2327cd323b0cce"
+  integrity sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==
   dependencies:
-    protons "^1.0.1"
+    buffer "^5.2.1"
+    is-buffer "^2.0.3"
+    is-electron "^2.2.0"
+    is-pull-stream "0.0.0"
+    is-stream "^2.0.0"
+    kind-of "^6.0.2"
+    readable-stream "^3.4.0"
 
-ipld-dag-cbor@~0.13.0:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/ipld-dag-cbor/-/ipld-dag-cbor-0.13.1.tgz#2ffecba3a13b29d8b604ee3d9b5dad0d4542e26b"
-  integrity sha512-96KKh5XUq9LrWE/TQ/BOJ5FcQx7UZ892N76ufDdovq+fIwZ4/YpPRTAVssLUuN3crATHoGu80TVZMgevsuTCdQ==
+ipld-dag-cbor@~0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/ipld-dag-cbor/-/ipld-dag-cbor-0.15.0.tgz#1fbebef1c2d8b980fb18b94f96ec3c1f1d32f860"
+  integrity sha512-wc9nrDtV4Le76UUhG4LXX57NVi5d7JS2kLid2nOYZAcr0SFhiXZL2ZyV3bfmNohO50KvgPEessSaBBSm9bflGA==
   dependencies:
     borc "^2.1.0"
-    bs58 "^4.0.1"
-    cids "~0.5.5"
+    cids "~0.7.0"
     is-circular "^1.0.2"
-    multihashes "~0.4.14"
-    multihashing-async "~0.5.1"
-    traverse "~0.6.6"
+    multicodec "~0.5.0"
+    multihashing-async "~0.7.0"
 
-ipld-dag-pb@~0.15.0:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.15.3.tgz#0f72b99e77e3265f722457de5dc63b0f700fbb7d"
-  integrity sha512-J1RJzSVCaOpxPmSzXbwVNsAZPHctjY4OjqG1dMIG86Z37CKvuy1QwCFkDhNccUTcQpF3sXfj5e0ZUyMM035vzg==
+ipld-dag-pb@~0.17.3:
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz#080841cfdd014d996f8da7f3a522ec8b1f6b6494"
+  integrity sha512-YwCxETEMuXVspOKOhjIOHJvKvB/OZfCDkpSFiYBQN2/JQjM9y/RFCYzIQGm0wg7dCFLrhvfjAZLTSaKs65jzWA==
   dependencies:
-    async "^2.6.1"
-    bs58 "^4.0.1"
-    cids "~0.5.4"
+    cids "~0.7.0"
     class-is "^1.1.0"
-    is-ipfs "~0.6.0"
-    multihashing-async "~0.5.1"
+    multicodec "~0.5.1"
+    multihashing-async "~0.7.0"
     protons "^1.0.1"
-    pull-stream "^3.6.9"
-    pull-traverse "^1.0.3"
     stable "~0.1.8"
+
+ipld-raw@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ipld-raw/-/ipld-raw-4.0.0.tgz#dd31f75dba2fad9cc8bb084d07ce1ea74fd47734"
+  integrity sha512-yNQG5zQqm/RH8aNQxcvcsAdHJW4q+LJ3cPfFzHOtujEa/PRlT5YCOVpAFh61HfpsWFm2GJrb2G+HHgtDDlFSMw==
+  dependencies:
+    cids "~0.7.0"
+    multicodec "~0.5.0"
+    multihashing-async "~0.7.0"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -4353,10 +4469,22 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-binary-path@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
@@ -4409,6 +4537,11 @@ is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
+is-electron@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
+  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -4463,7 +4596,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -4482,17 +4615,7 @@ is-ip@^2.0.0:
   dependencies:
     ip-regex "^2.0.0"
 
-is-ipfs@~0.4.7:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.4.8.tgz#ea229aef6230433ad1e8df930c49c5e773422c3f"
-  integrity sha512-xIKUeA24IFMfkmeAPEOZL448X7a08c/KzAGQp1e/QxC9bx/NNEdT/ohob3SW6eJO2UwJNjsbfMeNZ2B+Dk2Fdg==
-  dependencies:
-    bs58 "4.0.1"
-    cids "~0.5.6"
-    multibase "~0.6.0"
-    multihashes "~0.4.13"
-
-is-ipfs@~0.6.0:
+is-ipfs@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.6.1.tgz#c85069c73275dc6a60673c791a9be731e2b4bfc4"
   integrity sha512-WhqQylam6pODS2RyqT/u0PR5KWtBZNCgPjgargFOVQjzw/3+6d0midXenzU65klM4LH13IUiCC6ObhDUdXZ7Nw==
@@ -4515,6 +4638,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-object@^1.0.1:
   version "1.0.1"
@@ -4565,6 +4693,11 @@ is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
 is-symbol@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
@@ -4607,7 +4740,16 @@ iso-random-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/iso-random-stream/-/iso-random-stream-1.1.0.tgz#c1dc1bb43dd8da6524df9cbc6253b010806585c8"
   integrity sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ==
 
-iso-url@~0.4.4:
+iso-stream-http@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/iso-stream-http/-/iso-stream-http-0.1.2.tgz#b3dfea4c9f23ff26d078d40c539cfc0dfebacd37"
+  integrity sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
+
+iso-url@~0.4.4, iso-url@~0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/iso-url/-/iso-url-0.4.6.tgz#45005c4af4984cad4f8753da411b41b74cf0a8a6"
   integrity sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg==
@@ -4665,15 +4807,22 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+iterable-ndjson@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz#36f7e8a5bb04fd087d384f29e44fc4280fc014fc"
+  integrity sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==
+  dependencies:
+    string_decoder "^1.2.0"
+
 iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
-jayson@^2.0.6:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/jayson/-/jayson-2.1.2.tgz#3612f578529b5cc84301f098f29cd1612119e53d"
-  integrity sha512-2GejcQnEV35KYTXoBvzALIDdO/1oyEIoJHBnaJFhJhcurv0x2JqUXQW6xlDUhcNOpN9t+d2w+JGA6vOphb+5mg==
+jayson@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-3.0.2.tgz#3fdd1ba8d780fe4600d2f9aa80a8639f3a799b08"
+  integrity sha512-jru45VNl0S9tkwNxd9ZlAwAJpAFZaCTy9GVgPhDocCSs32bysslYTrbvTq/QrrFDLp2q6M81q3S6qxvS43AMPg==
   dependencies:
     "@types/node" "^10.3.5"
     JSONStream "^1.3.1"
@@ -4849,6 +4998,16 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-kebab-case@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/just-kebab-case/-/just-kebab-case-1.1.0.tgz#ebe854fde84b0afa4e597fcd870b12eb3c026755"
+  integrity sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA==
+
+just-map-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/just-map-keys/-/just-map-keys-1.1.0.tgz#9663c9f971ba46e17f2b05e66fec81149375f230"
+  integrity sha512-oNKi+4y7fr8lXnhKYpBbCkiwHRVkAnx0VDkCeTDtKKMzGr1Lz1Yym+RSieKUTKim68emC5Yxrb4YmiF9STDO+g==
+
 keccak@^1.0.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-1.4.0.tgz#572f8a6dbee8e7b3aa421550f9e6408ca2186f80"
@@ -4910,6 +5069,19 @@ klaw@^1.0.0:
   integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
   optionalDependencies:
     graceful-fs "^4.1.9"
+
+ky-universal@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ky-universal/-/ky-universal-0.2.2.tgz#7a36e1a75641a98f878157463513965f799f5bfe"
+  integrity sha512-fb32o/fKy/ux2ALWa9HU2hvGtfOq7/vn2nH0FpVE+jwNzyTeORlAbj3Fiw+WLMbUlmVqZIWupnLZ2USHvqwZHw==
+  dependencies:
+    abort-controller "^3.0.0"
+    node-fetch "^2.3.0"
+
+ky@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.11.2.tgz#4ffe6621d9d9ab61bf0f5500542e3a96d1ba0815"
+  integrity sha512-5Aou5BWue5/mkPqIRqzSWW+0Hkl403pr/2AIrCKYw7cVl/Xoe8Xe4KLBO0PRjbz7GnRe1/8wW1KhqQNFFE7/GQ==
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -5051,7 +5223,7 @@ libp2p-crypto-secp256k1@~0.3.0:
     safe-buffer "^5.1.2"
     secp256k1 "^3.6.1"
 
-libp2p-crypto@~0.16.0:
+libp2p-crypto@~0.16.0, libp2p-crypto@~0.16.1:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz#40aa07e95a0a7fe6887ea3868625e74c81c34d75"
   integrity sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==
@@ -5186,6 +5358,11 @@ lodash@=4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
+
+lodash@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -5515,13 +5692,25 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-multiaddr@^6.0.0, multiaddr@^6.0.3, multiaddr@^6.0.4:
+multiaddr@^6.0.3, multiaddr@^6.0.4:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-6.0.6.tgz#99296d219d4f21b6520c7eaf43fd3ef9306d7a63"
   integrity sha512-nR4s91mi7IKed1jrqUj/4OhZ1VKdAjUG79IuVB5PS6b+qxOZLKPW8nsskHhrfGn4o1Rn1NJWl7znidF/NVQpEA==
   dependencies:
     bs58 "^4.0.1"
     class-is "^1.1.0"
+    ip "^1.1.5"
+    is-ip "^2.0.0"
+    varint "^5.0.0"
+
+multiaddr@^6.0.6:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-6.1.1.tgz#9aae57b3e399089b9896d9455afa8f6b117dff06"
+  integrity sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==
+  dependencies:
+    bs58 "^4.0.1"
+    class-is "^1.1.0"
+    hi-base32 "~0.5.0"
     ip "^1.1.5"
     is-ip "^2.0.0"
     varint "^5.0.0"
@@ -5548,6 +5737,14 @@ multihashes@~0.4.13, multihashes@~0.4.14:
     bs58 "^4.0.1"
     varint "^5.0.0"
 
+multihashes@~0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-0.4.15.tgz#6dbc55f7f312c6782f5367c03c9783681589d8a6"
+  integrity sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==
+  dependencies:
+    bs58 "^4.0.1"
+    varint "^5.0.0"
+
 multihashing-async@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/multihashing-async/-/multihashing-async-0.5.2.tgz#4af40e0dde2f1dbb12a7c6b265181437ac26b9de"
@@ -5558,6 +5755,23 @@ multihashing-async@~0.5.1:
     multihashes "~0.4.13"
     murmurhash3js "^3.0.1"
     nodeify "^1.0.1"
+
+multihashing-async@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/multihashing-async/-/multihashing-async-0.7.0.tgz#3234fb98295be84386b85bfd20377d3e5be20d6b"
+  integrity sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==
+  dependencies:
+    blakejs "^1.1.0"
+    buffer "^5.2.1"
+    err-code "^1.1.2"
+    js-sha3 "~0.8.0"
+    multihashes "~0.4.13"
+    murmurhash3js-revisited "^3.0.0"
+
+murmurhash3js-revisited@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz#6bd36e25de8f73394222adc6e41fa3fac08a5869"
+  integrity sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==
 
 murmurhash3js@^3.0.1:
   version "3.0.1"
@@ -5615,15 +5829,14 @@ napi-build-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.1.tgz#1381a0f92c39d66bf19852e7873432fc2123e508"
   integrity sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==
 
-ndjson@^1.5.0:
+"ndjson@github:hugomrdias/ndjson#feat/readable-stream3":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/ndjson/-/ndjson-1.5.0.tgz#ae603b36b134bcec347b452422b0bf98d5832ec8"
-  integrity sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=
+  resolved "https://codeload.github.com/hugomrdias/ndjson/tar.gz/4db16da6b42e5b39bf300c3a7cde62abb3fa3a11"
   dependencies:
     json-stringify-safe "^5.0.1"
     minimist "^1.2.0"
-    split2 "^2.1.0"
-    through2 "^2.0.3"
+    split2 "^3.1.0"
+    through2 "^3.0.0"
 
 needle@^2.2.1:
   version "2.3.1"
@@ -6115,7 +6328,7 @@ pbkdf2@^3.0.17, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-peer-id@~0.12.1, peer-id@~0.12.2:
+peer-id@~0.12.2:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.12.2.tgz#0d1b876ebf21a528be9948c9cb7d30266342b2fd"
   integrity sha512-pked3yPLcOcprH21OnYbJAzk9OgI/TDEqjJ0IfRJSVB/61ZyqU5VKO7cw7hul+YD8nTD79wM79xFRWN3f6otNg==
@@ -6125,7 +6338,17 @@ peer-id@~0.12.1, peer-id@~0.12.2:
     libp2p-crypto "~0.16.0"
     multihashes "~0.4.13"
 
-peer-info@~0.15.0:
+peer-id@~0.12.3:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.12.4.tgz#25708b0676ee0a8b0ce32d73fe9c68163ed747c2"
+  integrity sha512-AIAwL/6CmVc/VKbUhpA1rY3A/VJ3Z9ELvtvDQfl5cIi0A74L7lvsJ6LxQn5JSJVHM5Us2Ng9zMO523dO3FFnnw==
+  dependencies:
+    async "^2.6.3"
+    class-is "^1.1.0"
+    libp2p-crypto "~0.16.1"
+    multihashes "~0.4.15"
+
+peer-info@~0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/peer-info/-/peer-info-0.15.1.tgz#21254a7c516d0dd046b150120b9aaf1b9ad02146"
   integrity sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==
@@ -6151,6 +6374,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picomatch@^2.0.4:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
+  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -6250,6 +6478,11 @@ process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
   integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
+
+promise-nodeify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/promise-nodeify/-/promise-nodeify-3.0.1.tgz#f0f5d9720ee9ec71dd2bfa92667be504c10229c2"
+  integrity sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg==
 
 promise-to-callback@^1.0.0:
   version "1.0.0"
@@ -6357,25 +6590,22 @@ pull-live@^1.0.1:
     pull-cat "^1.1.9"
     pull-stream "^3.4.0"
 
-pull-pushable@^2.0.0, pull-pushable@^2.2.0:
+pull-pushable@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/pull-pushable/-/pull-pushable-2.2.0.tgz#5f2f3aed47ad86919f01b12a2e99d6f1bd776581"
   integrity sha1-Xy867UethpGfAbEqLpnW8b13ZYE=
-
-pull-stream-to-stream@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz#3f81d8216bd18d2bfd1a198190471180e2738399"
-  integrity sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k=
 
 pull-stream@^3.2.3, pull-stream@^3.4.0, pull-stream@^3.6.8, pull-stream@^3.6.9:
   version "3.6.11"
   resolved "https://registry.yarnpkg.com/pull-stream/-/pull-stream-3.6.11.tgz#601956610952a76defdcb18e4435e2478659cead"
   integrity sha512-43brwtqO0OSltctKbW1mgzzKH4TNE8egkW+Y4BFzlDWiG2Ayl7VKr4SeuoKacfgPfUWcSwcPlHsf40BEqNR32A==
 
-pull-traverse@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pull-traverse/-/pull-traverse-1.0.3.tgz#74fb5d7be7fa6bd7a78e97933e199b7945866938"
-  integrity sha1-dPtde+f6a9enjpeTPhmbeUWGaTg=
+pull-to-stream@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pull-to-stream/-/pull-to-stream-0.1.1.tgz#fa2058528528e3542b81d6f17cbc42288508ff37"
+  integrity sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==
+  dependencies:
+    readable-stream "^3.1.1"
 
 pull-window@^2.1.4:
   version "2.1.4"
@@ -6536,7 +6766,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.0.6:
+"readable-stream@2 || 3", readable-stream@^3.0.2:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
   integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
@@ -6568,6 +6798,15 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.0.0, readable-stream@^3.0.1, readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@~1.0.15:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -6586,6 +6825,13 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+readdirp@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.1.2.tgz#fa85d2d14d4289920e4671dead96431add2ee78a"
+  integrity sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==
+  dependencies:
+    picomatch "^2.0.4"
 
 regenerate@^1.2.1:
   version "1.4.0"
@@ -6845,6 +7091,11 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 safe-event-emitter@^1.0.1:
   version "1.0.1"
@@ -7292,12 +7543,12 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
-  integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
+split2@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-3.1.1.tgz#c51f18f3e06a8c4469aaab487687d8d956160bb6"
+  integrity sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==
   dependencies:
-    through2 "^2.0.2"
+    readable-stream "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -7347,16 +7598,6 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-stream-http@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-3.0.0.tgz#bd6d3c52610098699e25eb2dfcd188e30e0d12e4"
-  integrity sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==
-  dependencies:
-    builtin-status-codes "^3.0.0"
-    inherits "^2.0.1"
-    readable-stream "^3.0.6"
-    xtend "^4.0.0"
-
 stream-to-pull-stream@^1.7.1, stream-to-pull-stream@^1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz#4161aa2d2eb9964de60bfa1af7feaf917e874ece"
@@ -7364,11 +7605,6 @@ stream-to-pull-stream@^1.7.1, stream-to-pull-stream@^1.7.2:
   dependencies:
     looper "^3.0.0"
     pull-stream "^3.2.3"
-
-streamifier@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/streamifier/-/streamifier-0.1.1.tgz#97e98d8fa4d105d62a2691d1dc07e820db8dfc4f"
-  integrity sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -7407,6 +7643,13 @@ string_decoder@^1.1.1:
   integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
   dependencies:
     safe-buffer "~5.1.0"
+
+string_decoder@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -7544,7 +7787,7 @@ tar-fs@^1.13.0:
     pump "^1.0.0"
     tar-stream "^1.1.2"
 
-tar-stream@^1.1.2, tar-stream@^1.5.2, tar-stream@^1.6.2:
+tar-stream@^1.1.2, tar-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
   integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
@@ -7556,6 +7799,17 @@ tar-stream@^1.1.2, tar-stream@^1.5.2, tar-stream@^1.6.2:
     readable-stream "^2.3.0"
     to-buffer "^1.1.1"
     xtend "^4.0.0"
+
+tar-stream@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.0.tgz#d1aaa3661f05b38b5acc9b7020efdca5179a2cc3"
+  integrity sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==
+  dependencies:
+    bl "^3.0.0"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar.gz@^1.0.5:
   version "1.0.7"
@@ -7604,7 +7858,7 @@ thenify-all@^1.0.0, thenify-all@^1.6.0:
   dependencies:
     any-promise "^1.0.0"
 
-through2@^2.0.2, through2@^2.0.3:
+through2@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -7612,7 +7866,7 @@ through2@^2.0.2, through2@^2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through2@^3.0.0:
+through2@^3.0.0, through2@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
   integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
@@ -7666,6 +7920,13 @@ to-regex-range@^2.1.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
@@ -7715,11 +7976,6 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
-
-traverse@~0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
-  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Changes:
- using templates as much a possible 
- avoid contract calls in favour of entity lookups wherever possible